### PR TITLE
Fixes to pass `golint`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1,5 +1,7 @@
 package raft
 
+// AppendEntriesRequest is the command used to append entries to the
+// replicated log.
 type AppendEntriesRequest struct {
 	// Provide the current term and leader
 	Term   uint64
@@ -16,6 +18,8 @@ type AppendEntriesRequest struct {
 	LeaderCommitIndex uint64
 }
 
+// AppendEntriesResponse is the response returned from an
+// AppendEntriesRequest.
 type AppendEntriesResponse struct {
 	// Newer term if leader is out of date
 	Term uint64
@@ -27,6 +31,8 @@ type AppendEntriesResponse struct {
 	Success bool
 }
 
+// RequestVoteRequest is the command used by a candidate to ask a Raft peer
+// for a vote in an election.
 type RequestVoteRequest struct {
 	// Provide the term and our id
 	Term      uint64
@@ -37,6 +43,7 @@ type RequestVoteRequest struct {
 	LastLogTerm  uint64
 }
 
+// RequestVoteResponse is the response returned from a RequestVoteRequest.
 type RequestVoteResponse struct {
 	// Newer term if leader is out of date
 	Term uint64
@@ -48,6 +55,8 @@ type RequestVoteResponse struct {
 	Granted bool
 }
 
+// InstallSnapshotRequest is the command sent to a Raft peer to bootstrap its
+// log (and state machine) from a snapshot on another peer.
 type InstallSnapshotRequest struct {
 	Term   uint64
 	Leader []byte
@@ -63,6 +72,8 @@ type InstallSnapshotRequest struct {
 	Size int64
 }
 
+// InstallSnapshotResponse is the response returned from an
+// InstallSnapshotRequest.
 type InstallSnapshotResponse struct {
 	Term    uint64
 	Success bool

--- a/config.go
+++ b/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	LogOutput io.Writer
 }
 
+// DefaultConfig returns a Config with usable defaults.
 func DefaultConfig() *Config {
 	return &Config{
 		HeartbeatTimeout:   1000 * time.Millisecond,

--- a/file_snapshot.go
+++ b/file_snapshot.go
@@ -35,7 +35,7 @@ type FileSnapshotStore struct {
 
 type snapMetaSlice []*fileSnapshotMeta
 
-// Implements the SnapshotSink
+// FileSnapshotSink implements SnapshotSink with a file.
 type FileSnapshotSink struct {
 	store  *FileSnapshotStore
 	logger *log.Logger
@@ -188,6 +188,7 @@ func (f *FileSnapshotStore) Create(index, term uint64, peers []byte) (SnapshotSi
 	return sink, nil
 }
 
+// List returns available snapshots in the store.
 func (f *FileSnapshotStore) List() ([]*SnapshotMeta, error) {
 	// Get the eligible snapshots
 	snapshots, err := f.getSnapshots()
@@ -269,6 +270,7 @@ func (f *FileSnapshotStore) readMeta(name string) (*fileSnapshotMeta, error) {
 	return meta, nil
 }
 
+// Open takes a snapshot ID and returns a ReadCloser for that snapshot.
 func (f *FileSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error) {
 	// Get the metadata
 	meta, err := f.readMeta(id)
@@ -321,7 +323,7 @@ func (f *FileSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error
 	return &meta.SnapshotMeta, buffered, nil
 }
 
-// Used to reap any snapshots beyond the retain count
+// ReapSnapshots reaps any snapshots beyond the retain count.
 func (f *FileSnapshotStore) ReapSnapshots() error {
 	snapshots, err := f.getSnapshots()
 	if err != nil {

--- a/inmem_store.go
+++ b/inmem_store.go
@@ -27,29 +27,34 @@ func NewInmemStore() *InmemStore {
 	return i
 }
 
+// FirstIndex implements the LogStore interface.
 func (i *InmemStore) FirstIndex() (uint64, error) {
 	return i.lowIndex, nil
 }
 
+// LastIndex implements the LogStore interface.
 func (i *InmemStore) LastIndex() (uint64, error) {
 	return i.highIndex, nil
 }
 
+// GetLog implements the LogStore interface.
 func (i *InmemStore) GetLog(index uint64, log *Log) error {
 	i.l.RLock()
 	defer i.l.RUnlock()
 	l, ok := i.logs[index]
 	if !ok {
-		return LogNotFound
+		return ErrLogNotFound
 	}
 	*log = *l
 	return nil
 }
 
+// StoreLog implements the LogStore interface.
 func (i *InmemStore) StoreLog(log *Log) error {
 	return i.StoreLogs([]*Log{log})
 }
 
+// StoreLogs implements the LogStore interface.
 func (i *InmemStore) StoreLogs(logs []*Log) error {
 	i.l.Lock()
 	defer i.l.Unlock()
@@ -65,17 +70,18 @@ func (i *InmemStore) StoreLogs(logs []*Log) error {
 	return nil
 }
 
+// DeleteRange implements the LogStore interface.
 func (i *InmemStore) DeleteRange(min, max uint64) error {
 	i.l.Lock()
 	defer i.l.Unlock()
 	for j := min; j <= max; j++ {
 		delete(i.logs, j)
-
 	}
 	i.lowIndex = max + 1
 	return nil
 }
 
+// Set implements the StableStore interface.
 func (i *InmemStore) Set(key []byte, val []byte) error {
 	i.l.Lock()
 	defer i.l.Unlock()
@@ -83,12 +89,14 @@ func (i *InmemStore) Set(key []byte, val []byte) error {
 	return nil
 }
 
+// Get implements the StableStore interface.
 func (i *InmemStore) Get(key []byte) ([]byte, error) {
 	i.l.RLock()
 	defer i.l.RUnlock()
 	return i.kv[string(key)], nil
 }
 
+// SetUint64 implements the StableStore interface.
 func (i *InmemStore) SetUint64(key []byte, val uint64) error {
 	i.l.Lock()
 	defer i.l.Unlock()
@@ -96,6 +104,7 @@ func (i *InmemStore) SetUint64(key []byte, val uint64) error {
 	return nil
 }
 
+// GetUint64 implements the StableStore interface.
 func (i *InmemStore) GetUint64(key []byte) (uint64, error) {
 	i.l.RLock()
 	defer i.l.RUnlock()

--- a/inmem_transport_test.go
+++ b/inmem_transport_test.go
@@ -17,7 +17,7 @@ func TestInmemAddr(t *testing.T) {
 	if inm.Network() != "inmem" {
 		t.Fatalf("bad network")
 	}
-	if inm.String() != inm.Id {
+	if inm.String() != inm.ID {
 		t.Fatalf("bad string")
 	}
 }

--- a/log.go
+++ b/log.go
@@ -1,36 +1,29 @@
 package raft
 
-import (
-	"fmt"
-	"net"
-)
+import "net"
 
+// LogType describes various types of log entries.
 type LogType uint8
 
 const (
-	// Commands are applied to a user FSM
+	// LogCommand is applied to a user FSM.
 	LogCommand LogType = iota
 
-	// Noop is used to assert leadership
+	// LogNoop is used to assert leadership.
 	LogNoop
 
-	// Used to add a new peer
+	// LogAddPeer is used to add a new peer.
 	LogAddPeer
 
-	// Used to remove an existing peer
+	// LogRemovePeer is used to remove an existing peer.
 	LogRemovePeer
 
-	// Barrier is used to ensure all preceeding
-	// operations have been applied to the FSM. It is
-	// similar to LogNoop, but instead of returning once committed,
-	// it only returns once the FSM manager acks it. Otherwise it is
-	// possible there are operations committed but not yet applied to
+	// LogBarrier is used to ensure all preceeding operations have been
+	// applied to the FSM. It is similar to LogNoop, but instead of returning
+	// once committed, it only returns once the FSM manager acks it. Otherwise
+	// it is possible there are operations committed but not yet applied to
 	// the FSM.
 	LogBarrier
-)
-
-var (
-	LogNotFound = fmt.Errorf("log not found")
 )
 
 // Log entries are replicated to all members of the Raft cluster

--- a/peer.go
+++ b/peer.go
@@ -20,23 +20,25 @@ const (
 // in a two node cluster, the failure of either node requires human intervention
 // since consensus is impossible.
 type PeerStore interface {
-	// Returns the list of known peers
+	// Peers returns the list of known peers.
 	Peers() ([]net.Addr, error)
 
-	// Sets the list of known peers. This is invoked when
-	// a peer is added or removed
+	// SetPeers sets the list of known peers. This is invoked when a peer is
+	// added or removed.
 	SetPeers([]net.Addr) error
 }
 
-// StatisPeers is used to provide a static list of peers
+// StaticPeers is used to provide a static list of peers.
 type StaticPeers struct {
 	StaticPeers []net.Addr
 }
 
+// Peers implements the PeerStore interface.
 func (s *StaticPeers) Peers() ([]net.Addr, error) {
 	return s.StaticPeers, nil
 }
 
+// SetPeers implements the PeerStore interface.
 func (s *StaticPeers) SetPeers(p []net.Addr) error {
 	s.StaticPeers = p
 	return nil
@@ -61,6 +63,7 @@ func NewJSONPeers(base string, trans Transport) *JSONPeers {
 	return store
 }
 
+// Peers implements the PeerStore interface.
 func (j *JSONPeers) Peers() ([]net.Addr, error) {
 	j.l.Lock()
 	defer j.l.Unlock()
@@ -91,6 +94,7 @@ func (j *JSONPeers) Peers() ([]net.Addr, error) {
 	return peers, nil
 }
 
+// SetPeers implements the PeerStore interface.
 func (j *JSONPeers) SetPeers(peers []net.Addr) error {
 	j.l.Lock()
 	defer j.l.Unlock()

--- a/snapshot.go
+++ b/snapshot.go
@@ -22,7 +22,7 @@ type SnapshotStore interface {
 	// with the current peer set already encoded
 	Create(index, term uint64, peers []byte) (SnapshotSink, error)
 
-	// List is used to list the available snapshots in the store
+	// List is used to list the available snapshots in the store.
 	// It should return then in descending order, with the highest index first.
 	List() ([]*SnapshotMeta, error)
 

--- a/state.go
+++ b/state.go
@@ -4,12 +4,21 @@ import (
 	"sync/atomic"
 )
 
+// RaftState captures the state of a Raft node: Follower, Candidate, Leader,
+// or Shutdown.
 type RaftState uint32
 
 const (
+	// Follower is the initial state of a Raft node.
 	Follower RaftState = iota
+
+	// Candidate is one of the valid states of a Raft node.
 	Candidate
+
+	// Leader is one of the valid states of a Raft node.
 	Leader
+
+	// Shutdown is the terminal state of a Raft node.
 	Shutdown
 )
 
@@ -155,7 +164,6 @@ func (r *raftState) getLastIndex() uint64 {
 func (r *raftState) getLastEntry() (uint64, uint64) {
 	if r.getLastLogIndex() >= r.getLastSnapshotIndex() {
 		return r.getLastLogIndex(), r.getLastLogTerm()
-	} else {
-		return r.getLastSnapshotIndex(), r.getLastSnapshotTerm()
 	}
+	return r.getLastSnapshotIndex(), r.getLastSnapshotTerm()
 }

--- a/tcp_transport_test.go
+++ b/tcp_transport_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestTCPTransport_BadAddr(t *testing.T) {
 	_, err := NewTCPTransport("0.0.0.0:0", nil, 1, 0, nil)
-	if err.Error() != "Local bind address is not advertisable!" {
+	if err != errNotAdvertisable {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/util.go
+++ b/util.go
@@ -5,10 +5,11 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"github.com/ugorji/go/codec"
 	"math/rand"
 	"net"
 	"time"
+
+	"github.com/ugorji/go/codec"
 )
 
 // randomTimeout returns a value that is between the minVal and 2x minVal
@@ -40,7 +41,7 @@ func max(a, b uint64) uint64 {
 func generateUUID() string {
 	buf := make([]byte, 16)
 	if _, err := crand.Read(buf); err != nil {
-		panic(fmt.Errorf("Failed to read random bytes: %v", err))
+		panic(fmt.Errorf("failed to read random bytes: %v", err))
 	}
 
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
@@ -103,9 +104,8 @@ func PeerContained(peers []net.Addr, peer net.Addr) bool {
 func AddUniquePeer(peers []net.Addr, peer net.Addr) []net.Addr {
 	if PeerContained(peers, peer) {
 		return peers
-	} else {
-		return append(peers, peer)
 	}
+	return append(peers, peer)
 }
 
 // encodePeers is used to serialize a list of peers
@@ -119,7 +119,7 @@ func encodePeers(peers []net.Addr, trans Transport) []byte {
 	// Encode the entire array
 	buf, err := encodeMsgPack(encPeers)
 	if err != nil {
-		panic(fmt.Errorf("Failed to encode peers: %v", err))
+		panic(fmt.Errorf("failed to encode peers: %v", err))
 	}
 
 	return buf.Bytes()
@@ -130,7 +130,7 @@ func decodePeers(buf []byte, trans Transport) []net.Addr {
 	// Decode the buffer first
 	var encPeers [][]byte
 	if err := decodeMsgPack(buf, &encPeers); err != nil {
-		panic(fmt.Errorf("Failed to decode peers: %v", err))
+		panic(fmt.Errorf("failed to decode peers: %v", err))
 	}
 
 	// Deserialize each peer


### PR DESCRIPTION
This PR makes primarily vanity changes (e.g. adding comments, changing error messages, fixing variable names) and a few structural changes (e.g. dropping `else` blocks from early return `if` statements) in order that the repo passes [golint](http://github.com/golang/lint).
