### PR TITLE
Use strings instead of net.Addr objects

### DIFF
--- a/future.go
+++ b/future.go
@@ -1,7 +1,6 @@
 package raft
 
 import (
-	"net"
 	"sync"
 	"time"
 )
@@ -81,7 +80,7 @@ func (l *logFuture) Response() interface{} {
 
 type peerFuture struct {
 	deferError
-	peers []net.Addr
+	peers []string
 }
 
 type shutdownFuture struct {
@@ -108,7 +107,7 @@ type reqSnapshotFuture struct {
 	// snapshot details provided by the FSM runner before responding
 	index    uint64
 	term     uint64
-	peers    []net.Addr
+	peers    []string
 	snapshot FSMSnapshot
 }
 

--- a/inmem_transport_test.go
+++ b/inmem_transport_test.go
@@ -1,26 +1,8 @@
 package raft
 
 import (
-	"net"
 	"testing"
 )
-
-func TestInmemAddrImpl(t *testing.T) {
-	var inm interface{} = NewInmemAddr()
-	if _, ok := inm.(net.Addr); !ok {
-		t.Fatalf("InmemAddr is not a net.Addr")
-	}
-}
-
-func TestInmemAddr(t *testing.T) {
-	inm := NewInmemAddr()
-	if inm.Network() != "inmem" {
-		t.Fatalf("bad network")
-	}
-	if inm.String() != inm.ID {
-		t.Fatalf("bad string")
-	}
-}
 
 func TestInmemTransportImpl(t *testing.T) {
 	var inm interface{} = &InmemTransport{}

--- a/log.go
+++ b/log.go
@@ -1,7 +1,5 @@
 package raft
 
-import "net"
-
 // LogType describes various types of log entries.
 type LogType uint8
 
@@ -36,7 +34,7 @@ type Log struct {
 
 	// Peer is not exported since it is not transmitted, only used
 	// internally to construct the Data field.
-	peer net.Addr
+	peer string
 }
 
 // LogStore is used to provide an interface for storing

--- a/net_transport_test.go
+++ b/net_transport_test.go
@@ -356,7 +356,7 @@ func TestNetworkTransport_EncodeDecode(t *testing.T) {
 	enc := trans1.EncodePeer(local)
 	dec := trans1.DecodePeer(enc)
 
-	if dec.String() != local.String() {
+	if dec != local {
 		t.Fatalf("enc/dec fail: %v %v", dec, local)
 	}
 }
@@ -443,7 +443,7 @@ func TestNetworkTransport_PooledConn(t *testing.T) {
 
 	// Check the conn pool size
 	addr := trans1.LocalAddr()
-	if len(trans2.connPool[addr.String()]) != 3 {
+	if len(trans2.connPool[addr]) != 3 {
 		t.Fatalf("Expected 2 pooled conns!")
 	}
 }

--- a/peer.go
+++ b/peer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -21,21 +20,21 @@ const (
 // since consensus is impossible.
 type PeerStore interface {
 	// Peers returns the list of known peers.
-	Peers() ([]net.Addr, error)
+	Peers() ([]string, error)
 
 	// SetPeers sets the list of known peers. This is invoked when a peer is
 	// added or removed.
-	SetPeers([]net.Addr) error
+	SetPeers([]string) error
 }
 
 // StaticPeers is used to provide a static list of peers.
 type StaticPeers struct {
-	StaticPeers []net.Addr
+	StaticPeers []string
 	l           sync.Mutex
 }
 
 // Peers implements the PeerStore interface.
-func (s *StaticPeers) Peers() ([]net.Addr, error) {
+func (s *StaticPeers) Peers() ([]string, error) {
 	s.l.Lock()
 	peers := s.StaticPeers
 	s.l.Unlock()
@@ -43,7 +42,7 @@ func (s *StaticPeers) Peers() ([]net.Addr, error) {
 }
 
 // SetPeers implements the PeerStore interface.
-func (s *StaticPeers) SetPeers(p []net.Addr) error {
+func (s *StaticPeers) SetPeers(p []string) error {
 	s.l.Lock()
 	s.StaticPeers = p
 	s.l.Unlock()
@@ -70,7 +69,7 @@ func NewJSONPeers(base string, trans Transport) *JSONPeers {
 }
 
 // Peers implements the PeerStore interface.
-func (j *JSONPeers) Peers() ([]net.Addr, error) {
+func (j *JSONPeers) Peers() ([]string, error) {
 	j.l.Lock()
 	defer j.l.Unlock()
 
@@ -93,7 +92,7 @@ func (j *JSONPeers) Peers() ([]net.Addr, error) {
 	}
 
 	// Deserialize each peer
-	var peers []net.Addr
+	var peers []string
 	for _, p := range peerSet {
 		peers = append(peers, j.trans.DecodePeer([]byte(p)))
 	}
@@ -101,7 +100,7 @@ func (j *JSONPeers) Peers() ([]net.Addr, error) {
 }
 
 // SetPeers implements the PeerStore interface.
-func (j *JSONPeers) SetPeers(peers []net.Addr) error {
+func (j *JSONPeers) SetPeers(peers []string) error {
 	j.l.Lock()
 	defer j.l.Unlock()
 

--- a/peer_test.go
+++ b/peer_test.go
@@ -2,7 +2,6 @@ package raft
 
 import (
 	"io/ioutil"
-	"net"
 	"os"
 	"testing"
 )
@@ -29,7 +28,7 @@ func TestJSONPeers(t *testing.T) {
 	}
 
 	// Initialize some peers
-	newPeers := []net.Addr{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
+	newPeers := []string{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
 	if err := store.SetPeers(newPeers); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/replication.go
+++ b/replication.go
@@ -3,7 +3,6 @@ package raft
 import (
 	"errors"
 	"fmt"
-	"net"
 	"sync"
 	"time"
 
@@ -26,7 +25,7 @@ var (
 )
 
 type followerReplication struct {
-	peer     net.Addr
+	peer     string
 	inflight *inflight
 
 	stopCh    chan uint64
@@ -249,7 +248,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 		s.failures++
 		return false, err
 	}
-	metrics.MeasureSince([]string{"raft", "replication", "installSnapshot", s.peer.String()}, start)
+	metrics.MeasureSince([]string{"raft", "replication", "installSnapshot", s.peer}, start)
 
 	// Check for a newer term, stop running
 	if resp.Term > req.Term {
@@ -311,7 +310,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 		} else {
 			s.setLastContact()
 			failures = 0
-			metrics.MeasureSince([]string{"raft", "replication", "heartbeat", s.peer.String()}, start)
+			metrics.MeasureSince([]string{"raft", "replication", "heartbeat", s.peer}, start)
 			s.notifyAll(resp.Success)
 		}
 	}
@@ -483,9 +482,9 @@ func (r *Raft) setNewLogs(req *AppendEntriesRequest, nextIndex, lastIndex uint64
 }
 
 // appendStats is used to emit stats about an AppendEntries invocation
-func appendStats(peer net.Addr, start time.Time, logs float32) {
-	metrics.MeasureSince([]string{"raft", "replication", "appendEntries", "rpc", peer.String()}, start)
-	metrics.IncrCounter([]string{"raft", "replication", "appendEntries", "logs", peer.String()}, logs)
+func appendStats(peer string, start time.Time, logs float32) {
+	metrics.MeasureSince([]string{"raft", "replication", "appendEntries", "rpc", peer}, start)
+	metrics.IncrCounter([]string{"raft", "replication", "appendEntries", "logs", peer}, logs)
 }
 
 // handleStaleTerm is used when a follower indicates that we have a stale term

--- a/tcp_transport_test.go
+++ b/tcp_transport_test.go
@@ -18,7 +18,7 @@ func TestTCPTransport_WithAdvertise(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if trans.LocalAddr() != addr {
+	if trans.LocalAddr() != "127.0.0.1:12345" {
 		t.Fatalf("bad: %v", trans.LocalAddr())
 	}
 }

--- a/transport.go
+++ b/transport.go
@@ -2,7 +2,6 @@ package raft
 
 import (
 	"io"
-	"net"
 	"time"
 )
 
@@ -32,27 +31,27 @@ type Transport interface {
 	Consumer() <-chan RPC
 
 	// LocalAddr is used to return our local address to distinguish from our peers
-	LocalAddr() net.Addr
+	LocalAddr() string
 
 	// AppendEntriesPipeline returns an interface that can be used to pipeline
 	// AppendEntries requests.
-	AppendEntriesPipeline(target net.Addr) (AppendPipeline, error)
+	AppendEntriesPipeline(target string) (AppendPipeline, error)
 
 	// AppendEntries sends the appropriate RPC to the target node
-	AppendEntries(target net.Addr, args *AppendEntriesRequest, resp *AppendEntriesResponse) error
+	AppendEntries(target string, args *AppendEntriesRequest, resp *AppendEntriesResponse) error
 
 	// RequestVote sends the appropriate RPC to the target node
-	RequestVote(target net.Addr, args *RequestVoteRequest, resp *RequestVoteResponse) error
+	RequestVote(target string, args *RequestVoteRequest, resp *RequestVoteResponse) error
 
 	// InstallSnapshot is used to push a snapshot down to a follower. The data is read from
 	// the ReadCloser and streamed to the client.
-	InstallSnapshot(target net.Addr, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error
+	InstallSnapshot(target string, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error
 
 	// EncodePeer is used to serialize a peer name
-	EncodePeer(net.Addr) []byte
+	EncodePeer(string) []byte
 
 	// DecodePeer is used to deserialize a peer name
-	DecodePeer([]byte) net.Addr
+	DecodePeer([]byte) string
 
 	// SetHeartbeatHandler is used to setup a heartbeat handler
 	// as a fast-pass. This is to avoid head-of-line blocking from

--- a/util.go
+++ b/util.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
-	"net"
 	"time"
 
 	"github.com/hashicorp/go-msgpack/codec"
@@ -79,10 +78,10 @@ func asyncNotifyBool(ch chan bool, v bool) {
 }
 
 // ExcludePeer is used to exclude a single peer from a list of peers
-func ExcludePeer(peers []net.Addr, peer net.Addr) []net.Addr {
-	otherPeers := make([]net.Addr, 0, len(peers))
+func ExcludePeer(peers []string, peer string) []string {
+	otherPeers := make([]string, 0, len(peers))
 	for _, p := range peers {
-		if p.String() != peer.String() {
+		if p != peer {
 			otherPeers = append(otherPeers, p)
 		}
 	}
@@ -90,9 +89,9 @@ func ExcludePeer(peers []net.Addr, peer net.Addr) []net.Addr {
 }
 
 // PeerContained checks if a given peer is contained in a list
-func PeerContained(peers []net.Addr, peer net.Addr) bool {
+func PeerContained(peers []string, peer string) bool {
 	for _, p := range peers {
-		if p.String() == peer.String() {
+		if p == peer {
 			return true
 		}
 	}
@@ -101,7 +100,7 @@ func PeerContained(peers []net.Addr, peer net.Addr) bool {
 
 // AddUniquePeer is used to add a peer to a list of existing
 // peers only if it is not already contained
-func AddUniquePeer(peers []net.Addr, peer net.Addr) []net.Addr {
+func AddUniquePeer(peers []string, peer string) []string {
 	if PeerContained(peers, peer) {
 		return peers
 	}
@@ -109,7 +108,7 @@ func AddUniquePeer(peers []net.Addr, peer net.Addr) []net.Addr {
 }
 
 // encodePeers is used to serialize a list of peers
-func encodePeers(peers []net.Addr, trans Transport) []byte {
+func encodePeers(peers []string, trans Transport) []byte {
 	// Encode each peer
 	var encPeers [][]byte
 	for _, p := range peers {
@@ -126,7 +125,7 @@ func encodePeers(peers []net.Addr, trans Transport) []byte {
 }
 
 // decodePeers is used to deserialie a list of peers
-func decodePeers(buf []byte, trans Transport) []net.Addr {
+func decodePeers(buf []byte, trans Transport) []string {
 	// Decode the buffer first
 	var encPeers [][]byte
 	if err := decodeMsgPack(buf, &encPeers); err != nil {
@@ -134,7 +133,7 @@ func decodePeers(buf []byte, trans Transport) []net.Addr {
 	}
 
 	// Deserialize each peer
-	var peers []net.Addr
+	var peers []string
 	for _, enc := range encPeers {
 		peers = append(peers, trans.DecodePeer(enc))
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -1,7 +1,6 @@
 package raft
 
 import (
-	"net"
 	"reflect"
 	"regexp"
 	"testing"
@@ -106,7 +105,7 @@ func TestAsyncNotify(t *testing.T) {
 }
 
 func TestExcludePeer(t *testing.T) {
-	peers := []net.Addr{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
+	peers := []string{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
 	peer := peers[2]
 
 	after := ExcludePeer(peers, peer)
@@ -119,7 +118,7 @@ func TestExcludePeer(t *testing.T) {
 }
 
 func TestPeerContained(t *testing.T) {
-	peers := []net.Addr{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
+	peers := []string{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
 
 	if !PeerContained(peers, peers[2]) {
 		t.Fatalf("Expect contained")
@@ -130,7 +129,7 @@ func TestPeerContained(t *testing.T) {
 }
 
 func TestAddUniquePeer(t *testing.T) {
-	peers := []net.Addr{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
+	peers := []string{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
 	after := AddUniquePeer(peers, peers[2])
 	if !reflect.DeepEqual(after, peers) {
 		t.Fatalf("unexpected append")
@@ -142,7 +141,7 @@ func TestAddUniquePeer(t *testing.T) {
 }
 
 func TestEncodeDecodePeers(t *testing.T) {
-	peers := []net.Addr{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
+	peers := []string{NewInmemAddr(), NewInmemAddr(), NewInmemAddr()}
 	_, trans := NewInmemTransport()
 
 	// Try to encode/decode


### PR DESCRIPTION
…on which only String() is ever called.

This frees callers from the need to implement their own type which wraps
a string, and also reduces the amount of code in the raft package.

I think the EncodePeer() and DecodePeer() methods may now also be
obsolete.