### PR TITLE
Test stability

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -48,7 +48,7 @@ func MakeRaft(t *testing.T, conf *Config) *RaftEnv {
 
 	// Set the config
 	if conf == nil {
-		conf = inmemConfig()
+		conf = inmemConfig(t)
 	}
 	env.conf = conf
 


### PR DESCRIPTION
2 main things in here
a) route logging from raft to testing.T.Log in tests, this reduces the output when running tests,while allowing you to see all the logging for failed tests.
b) various test tweaks, some of the timeouts weren't taking into account the randomization range on timeouts that are applied, other failures i saw were related to a leader getting elected, and then immediately another node starting an election, and so the cluster wasn't stable as the test progressed, and various state mismatches applied. The additional calls to Followers() tries to help with this, but it perhaps worth incorporating that into the cluster.Leader() func.

I still see this failure occasionally
--- FAIL: TestRaft_ApplyConcurrent_Timeout (0.18s)
	raft_test.go:183: [WARN] Fully Connecting
	raft_test.go:91: [INFO] raft: Node at 59c5a165-ace9-bfba-fc23-c216ee498bce [Follower] entering Follower state
	raft_test.go:91: [WARN] raft: Heartbeat timeout reached, starting election
	raft_test.go:91: [INFO] raft: Node at 59c5a165-ace9-bfba-fc23-c216ee498bce [Candidate] entering Candidate state
	raft_test.go:91: [DEBUG] raft: Votes needed: 1
	raft_test.go:91: [DEBUG] raft: Vote granted. Tally: 1
	raft_test.go:91: [INFO] raft: Election won. Tally: 1
	raft_test.go:91: [INFO] raft: Node at 59c5a165-ace9-bfba-fc23-c216ee498bce [Leader] entering Leader state
	raft_test.go:91: [INFO] raft: Disabling EnableSingleNode (bootstrap)
	raft_test.go:91: [DEBUG] raft: Node 59c5a165-ace9-bfba-fc23-c216ee498bce updated peer set (2): [59c5a165-ace9-bfba-fc23-c216ee498bce]
	raft_test.go:737: expected a timeout

Which i'll continue to poke at.

This should help considerably with issue #55 