### PR TITLE
Close transport on shutdown

### DIFF
--- a/inmem_transport.go
+++ b/inmem_transport.go
@@ -208,6 +208,11 @@ func (i *InmemTransport) DisconnectAll() {
 	i.pipelines = nil
 }
 
+func (i *InmemTransport) Close() error {
+	i.DisconnectAll()
+	return nil
+}
+
 func newInmemPipeline(trans *InmemTransport, peer *InmemTransport, addr string) *inmemPipeline {
 	i := &inmemPipeline{
 		trans:        trans,

--- a/raft.go
+++ b/raft.go
@@ -411,6 +411,7 @@ func (r *Raft) Shutdown() Future {
 	if !r.shutdown {
 		close(r.shutdownCh)
 		r.shutdown = true
+		r.trans.Close()
 		r.setState(Shutdown)
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -58,6 +58,9 @@ type Transport interface {
 	// disk IO. If a Transport does not support this, it can simply
 	// ignore the call, and push the heartbeat onto the Consumer channel.
 	SetHeartbeatHandler(cb func(rpc RPC))
+
+	// Close shuts down the transport
+	Close() error
 }
 
 // AppendPipeline is used for pipelining AppendEntries requests. It is used


### PR DESCRIPTION
My application needs to re-use the bind address that the Raft transport is using after it's been shutdown.
The transport seems to eventually shutdown however waiting on the shutdown Future is not enough to ensure that it will be available to bind to. This patch explicitly closes the transport.

If there is a better way of achieving the behaviour I need would be happy to implement.