### PR TITLE
Step down if we are processing a RemovePeer of the active leader

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -918,7 +918,7 @@ func (r *Raft) leaderLoop() {
 			for i := 0; i < n; i++ {
 				// Fail all future transactions once stepDown is on
 				if stepDown {
-					ready[i].respond(ErrLeadershipLost)
+					ready[i].respond(ErrNotLeader)
 					ready[i], ready[n-1] = ready[n-1], nil
 					n--
 					i--

--- a/raft.go
+++ b/raft.go
@@ -849,6 +849,14 @@ func (r *Raft) startReplication(peer string) {
 // leaderLoop is the hot loop for a leader. It is invoked
 // after all the various leader setup is done.
 func (r *Raft) leaderLoop() {
+	// stepDown is used to track if there is an inflight log that
+	// would cause us to lose leadership (specifically a RemovePeer of
+	// ourselves). If this is the case, we must not allow any logs to
+	// be processed in parallel, otherwise we are basing commit on
+	// only a single peer (ourself) and replicating to an undefined set
+	// of peers.
+	stepDown := false
+
 	lease := time.After(r.conf.LeaderLeaseTimeout)
 	for r.getState() == Leader {
 		select {
@@ -908,13 +916,24 @@ func (r *Raft) leaderLoop() {
 			// Handle any peer set changes
 			n := len(ready)
 			for i := 0; i < n; i++ {
+				// Fail all future transactions once stepDown is on
+				if stepDown {
+					ready[i].respond(ErrLeadershipLost)
+					ready[i], ready[n-1] = ready[n-1], nil
+					n--
+					i--
+					continue
+				}
+
 				// Special case AddPeer and RemovePeer
 				log := ready[i]
 				if log.log.Type != LogAddPeer && log.log.Type != LogRemovePeer {
 					continue
 				}
 
-				// Check if this log should be ignored
+				// Check if this log should be ignored. The logs can be
+				// reordered here since we have not yet assigned an index
+				// and are not violating any promises.
 				if !r.preparePeerChange(log) {
 					ready[i], ready[n-1] = ready[n-1], nil
 					n--
@@ -922,8 +941,13 @@ func (r *Raft) leaderLoop() {
 					continue
 				}
 
-				// Apply peer set changes early
-				r.processLog(&log.log, nil, true)
+				// Apply peer set changes early and check if we will step
+				// down after the commit of this log. If so, we must not
+				// allow any future entries to make progress to avoid undefined
+				// behavior.
+				if ok := r.processLog(&log.log, nil, true); ok {
+					stepDown = true
+				}
 			}
 
 			// Nothing to do if all logs are invalid
@@ -1129,7 +1153,8 @@ func (r *Raft) processLogs(index uint64, future *logFuture) {
 }
 
 // processLog is invoked to process the application of a single committed log.
-func (r *Raft) processLog(l *Log, future *logFuture, precommit bool) {
+// Returns if this log entry would cause us to stepDown after it commits.
+func (r *Raft) processLog(l *Log, future *logFuture, precommit bool) (stepDown bool) {
 	switch l.Type {
 	case LogBarrier:
 		// Barrier is handled by the FSM
@@ -1160,6 +1185,7 @@ func (r *Raft) processLog(l *Log, future *logFuture, precommit bool) {
 		if removeSelf {
 			r.peers = nil
 			r.peerStore.SetPeers([]string{r.localAddr})
+			stepDown = true
 		} else {
 			r.peers = ExcludePeer(peers, r.localAddr)
 			r.peerStore.SetPeers(peers)
@@ -1214,6 +1240,7 @@ func (r *Raft) processLog(l *Log, future *logFuture, precommit bool) {
 	if future != nil && !precommit {
 		future.respond(nil)
 	}
+	return
 }
 
 // processRPC is called to handle an incoming RPC request.

--- a/raft_test.go
+++ b/raft_test.go
@@ -912,7 +912,7 @@ func TestRaft_RemoveLeader_NoShutdown(t *testing.T) {
 			removeFuture = leader.RemovePeer(leader.localAddr)
 		}
 		if i > 80 {
-			if err := future.Error(); err == nil || (err != ErrLeadershipLost && err != ErrNotLeader) {
+			if err := future.Error(); err == nil || err != ErrNotLeader {
 				t.Fatalf("err: %v, future entries should fail", err)
 			}
 		}

--- a/raft_test.go
+++ b/raft_test.go
@@ -907,9 +907,14 @@ func TestRaft_RemoveLeader_NoShutdown(t *testing.T) {
 	// Remove the leader
 	var removeFuture Future
 	for i := byte(0); i < 100; i++ {
-		leader.Apply([]byte{i}, 0)
+		future := leader.Apply([]byte{i}, 0)
 		if i == 80 {
 			removeFuture = leader.RemovePeer(leader.localAddr)
+		}
+		if i > 80 {
+			if err := future.Error(); err == nil || (err != ErrLeadershipLost && err != ErrNotLeader) {
+				t.Fatalf("err: %v, future entries should fail", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #79. Currently if there is an inflight RemovePeer(Leader), the active leader will set the quorum size to 1 which causes all future transactions to immediately Apply and replicate to the existing peers. This causes undefined behavior. In a completely serial world, we would expect all transactions on the current leader after the RemovePeer(Leader) to fail, as its no longer a valid peer or leader.

This PR changes the behavior to track if we have an inflight command that would cause us to step down. If so, we preemptively fail all future Apply's with an `ErrNotLeader` which is used to convey that the current node is not the leader and that we have not even attempted replication of the entry.