### PR TITLE
Reset heartbeat on a RequestVote RPC call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 
 go:
-    - 1.2
+    - 1.4
+    - 1.5
+    - 1.6
     - tip
 
 install: make deps

--- a/raft.go
+++ b/raft.go
@@ -1481,6 +1481,7 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 	}
 
 	resp.Granted = true
+	r.setLastContact()
 	return
 }
 


### PR DESCRIPTION
Heartbeat timers are randomized. This means that (all other things being equal) they may elapse and cause a node to enter candidate state at any time. The heartbeat timer is currently reset when a candidate receives a valid `AppendEntries` RPC call.

This causes an issue as a node that has just voted for a candidate may immediately declare itself a candidate. For instance in a new 3 node cluster, Node A declares itself a candidate, Node A votes
for itself, and Node B votes for node A too. Shortly afterwards (but before an `AppendEntries` heartbeat is sent by Node A), Node B's heartbeat timer expires, and Node B starts an election.

This causes an issue within the test suite, characterised by about 1%-2% of test runs failing. In particular A is detected as the leader, and B is subsequently detected as the leader. Issue #90 describes this in more detail.

The raft specification (section 5.2 of the paper, section 3.4 of the thesis), says (my emphasis):

> A server remains in follower state as long as it receives valid RPCs from a leader **or candidate** 

It is thus intended that a node in receipt of a 'valid' `RequestVote` RPC from a candidate should not declare itself a candidate (but should remain in follower state) for at least the Heartbeat interval.

It isn't entirely clear what a 'valid' `RequestVote` RPC means, but certainly one that is voted on is valid, and this is the smallest change.

This one line change thus resets the heartbeat timer if a vote is cast in favour, and thus removes the 1%-2% of tests failing for this reason.

Signed-off-by: Alex Bligh <alex@alex.org.uk>