### PR TITLE
Travis: build on more recent versions of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 
 go:
-    - 1.2
+    - 1.4
+    - 1.5
+    - 1.6
     - tip
 
 install: make deps


### PR DESCRIPTION
Travis integration is currently failing due to failure to build on go 1.2. Building on tip seems to work fine. Remove 1.2 (I don't know why it's failing, but 1.2 is prehistoric), and add 1.4, 1.5, 1.6.

Signed-off-by: Alex Bligh <alex@alex.org.uk>