### PR TITLE
Compare logs correctly on a RequestVote

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1468,7 +1468,7 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 		return
 	}
 
-	if lastIdx > req.LastLogIndex {
+	if lastTerm == req.LastLogTerm && lastIdx > req.LastLogIndex {
 		r.logger.Printf("[WARN] raft: Rejecting vote request from %v since our last index is greater (%d, %d)",
 			candidate, lastIdx, req.LastLogIndex)
 		return


### PR DESCRIPTION
Per issue #94:

> The log comparison in the RequestVote request handler is incorrect. The current code,
> rejects the request if the voter's last log term is greater than the candidate's OR
> if the voter's last log index is greater than the candidate's.

It should actually only compare the log index if the last terms are equal.

Signed-off-by: Alex Bligh <alex@alex.org.uk>