### PR TITLE
Ensure we don't call the shutdown future more than once

### DIFF
--- a/future.go
+++ b/future.go
@@ -97,6 +97,9 @@ type shutdownFuture struct {
 }
 
 func (s *shutdownFuture) Error() error {
+	if s.raft == nil {
+		return nil
+	}
 	for s.raft.getRoutines() > 0 {
 		time.Sleep(5 * time.Millisecond)
 	}

--- a/raft.go
+++ b/raft.go
@@ -412,9 +412,11 @@ func (r *Raft) Shutdown() Future {
 		close(r.shutdownCh)
 		r.shutdown = true
 		r.setState(Shutdown)
+		return &shutdownFuture{r}
 	}
 
-	return &shutdownFuture{r}
+	// avoid closing transport twice
+	return &shutdownFuture{nil}
 }
 
 // Snapshot is used to manually force Raft to take a snapshot.

--- a/raft_test.go
+++ b/raft_test.go
@@ -451,7 +451,10 @@ func TestRaft_AfterShutdown(t *testing.T) {
 	}
 
 	// Should be idempotent
-	raft.Shutdown()
+	if f := raft.Shutdown(); f.Error() != nil {
+		t.Fatalf("shutdown should be idempotent")
+	}
+
 }
 
 func TestRaft_SingleNode(t *testing.T) {


### PR DESCRIPTION
When shutting down a raft object, we should not run run anything significant in the shutdown future more than once. This was not previously a problem, but now we `Close()` the transport if it is closeable, and we shouldn't close it more than once.

Signed-off-by: Alex Bligh <alex@alex.org.uk>