### PR TITLE
Change calculation of heartbeat timer reset

### DIFF
--- a/util.go
+++ b/util.go
@@ -28,13 +28,30 @@ func newSeed() int64 {
 	return r.Int64()
 }
 
+// latest returns the latest of two times
+func latest(t1 time.Time, t2 time.Time) time.Time {
+	if t1.After(t2) {
+		return t1
+	} else {
+		return t2
+	}
+}
+
+// randomDuration returns a randomized duration between the minVal and 2 x minVal
+func randomDuration(minVal time.Duration) time.Duration {
+	if minVal == 0 {
+		return 0
+	}
+	extra := (time.Duration(rand.Int63()) % minVal)
+	return minVal + extra
+}
+
 // randomTimeout returns a value that is between the minVal and 2x minVal.
 func randomTimeout(minVal time.Duration) <-chan time.Time {
 	if minVal == 0 {
 		return nil
 	}
-	extra := (time.Duration(rand.Int63()) % minVal)
-	return time.After(minVal + extra)
+	return time.After(randomDuration(minVal))
 }
 
 // min returns the minimum.


### PR DESCRIPTION
According to the raft spec, we should time out between 1 and 2 intervals (here called `r.conf.HeartbeatTimeout`) after the last contact. Before this change, the heartbeat timeout was set to between 1 and 2 intervals after `Now()`. `Now()` may be substantially after the last contact as it itself
is driven by a heartbeat timeout.

There is a possibility that this value (1 and 2 intervals since last contact) is before `Now()`. So what we do is take a randomized interval from the later of the last interval and `Now() - r.conf.HeartbeatTimeout`.

I have measured the effect of this change using 1,000 iterations of TestRaft_TripleNode. In essence there is no measurable difference in the total time to complete an election. The attached graph shows the % of samples of time to complete the election process which were completed below the value on the y axis.

<img width="733" alt="screen shot 2016-03-23 at 12 16 22" src="https://cloud.githubusercontent.com/assets/1240226/13984924/4b465216-f0f1-11e5-9437-20d98428dc9f.png">

What it does improve however is the total time for a given election cycle (i.e. with the same term). The reason why this does not show in the end statistics is as follows:
- Elections where more than one node becomes a candidate during the election period are comparatively rare
- In those elections (only), we are concerned about the time taken for a follower to go into candidate state, and the fact this may sometimes be too long. Much of the time another follower will take the position.

However, this does appear to fix one cause of approximately 1 in 1,000 tests failing (once a number of other bugs in `raft_test.go` have been fixed). I think it's at worst harmless and at best a fix.

Note that a very substantial performance improvement to election convergence can be made (but has not been made) by using the same algorithm on the first setting of the heartbeat timer (when `runFollower` is started). This removes about 50ms off the time taken for an election. In essence we'd go to candidate state a random interval between 0 and 50ms after start, rather than 50ms and 100ms after start. This change should _not_ be made as such because a new follower joining a cluster would be quite likely to start an election. There is, however, probably an optimisation to be made where if a cluster is new (rather than an existing cluster being joined) we wait less time.

Note that though this is failing the integration tests, this is due to another bug in the integration tests (which I am fixing elsewhere).

Signed-off-by: Alex Bligh alex@alex.org.uk
