### PR TITLE
Stop truncating non-conflicting entries in AppendEntries

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1425,9 +1425,7 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 
 			// Update the lastLog
 			last := newEntries[n-1]
-			if last.Index > lastLogIdx {
-				r.setLastLog(last.Index, last.Term)
-			}
+			r.setLastLog(last.Index, last.Term)
 		}
 
 		metrics.MeasureSince([]string{"raft", "rpc", "appendEntries", "storeLogs"}, start)

--- a/raft.go
+++ b/raft.go
@@ -1420,6 +1420,8 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 			// Append the new entries
 			if err := r.logs.StoreLogs(newEntries); err != nil {
 				r.logger.Printf("[ERR] raft: Failed to append to logs: %v", err)
+				// TODO: leaving r.getLastLog() in the wrong
+				// state if there was a truncation above
 				return
 			}
 

--- a/raft_test.go
+++ b/raft_test.go
@@ -1845,3 +1845,32 @@ func TestRaft_Voting(t *testing.T) {
 		c.FailNowf("[ERR] expected vote not to be granted, but was %+v", resp)
 	}
 }
+
+// TODO: These are test cases we'd like to write for appendEntries().
+// Unfortunately, it's difficult to do so with the current way this file is
+// tested.
+//
+// Term check:
+// - m.term is too small: no-op.
+// - m.term is too large: update term, become follower, process request.
+// - m.term is right but we're candidate: become follower, process request.
+//
+// Previous entry check:
+// - prev is within the snapshot, before the snapshot's index: assume match.
+// - prev is within the snapshot, exactly the snapshot's index: check
+//   snapshot's term.
+// - prev is a log entry: check entry's term.
+// - prev is past the end of the log: return fail.
+//
+// New entries:
+// - new entries are all new: add them all.
+// - new entries are all duplicate: ignore them all without ever removing dups.
+// - new entries some duplicate, some new: add the new ones without ever
+//   removing dups.
+// - new entries all conflict: remove the conflicting ones, add their
+//   replacements.
+// - new entries some duplicate, some conflict: remove the conflicting ones,
+//   add their replacement, without ever removing dups.
+//
+// Storage errors handled properly.
+// Commit index updated properly.


### PR DESCRIPTION
## Copy of commit message

The AppendEntries request handler used to temporarily truncate entries
from the store that had indexes overlapping with the request, then it'd
go back and add all the entries in the request. This opened a window
of vulnerability during which if the server crashed, it could have
deleted some log entries that it shouldn't have.

For this to happen, the follower would have to receive an AppendEntries
request with entries that it already had. In principle, that could be
due to a duplicate request (depends on transport behavior) or to a
leader with a nextIndex set too low (probably isn't supposed to happen
with the back-up-one-entry algorithm).

The new code truncates only conflicting entries from the log store, then
appends only the new entries.

This also fixes a related issue where the last log index and term are
set to the last entry in the request, even if the last entry in the
request is not the last entry in the log (suppose the request contained
an earlier subsequence of the existing log).

## Discussion items

 - Is this introducing new problems of accessing the store non-atomically (#84)? Are RPC handlers allowed to run concurrently?

 - I think the best way to unit test this `appendEntries` function would be with a server that's in an interesting state (say, with a snapshot and a few log entries), and injecting hand-crafted AppendEntries requests into it to see how it behaves. I don't want a leader running or the servers to start elections. I didn't look through all of them, but I don't think the current tests are written in that style. How should I do that?
  - I probably further need to inject a thing into the middle of this function to test this particular change, that only the minimal set of entries got truncated. Or if I could get at stats on the log store, that would work too.

/cc @superfell @abligh 