### PR TITLE
buffer applyCh with up to conf.MaxAppendEntries

### DIFF
--- a/api.go
+++ b/api.go
@@ -478,7 +478,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	// Create Raft struct.
 	r := &Raft{
 		protocolVersion:       protocolVersion,
-		applyCh:               make(chan *logFuture),
+		applyCh:               make(chan *logFuture, conf.MaxAppendEntries),
 		conf:                  *conf,
 		fsm:                   fsm,
 		fsmMutateCh:           make(chan interface{}, 128),


### PR DESCRIPTION
This change improves throughput in busy Raft clusters.
By buffering messages, individual RPCs contain more Raft messages.
In my tests, this improves throughput from about 4.5 kqps to about 5.5 kqps.

As-is:
![n1-standard-8-c8deaa9d333f69fb56c8935036e7ca5c-no-buffer](https://cloud.githubusercontent.com/assets/55506/16059053/99c91f32-3281-11e6-8857-c28eb55fdd9e.png)

With my change:
![n1-standard-8-f2fed4ebe05df23eb322c805b503a144](https://cloud.githubusercontent.com/assets/55506/16059061/a14dcafa-3281-11e6-89c2-c98f089f8975.png)

(Both tests were performed with 3 n1-standard-8 nodes on Google Compute Engine in the europe-west1-d region.)
