### PR TITLE
Fixes tests and plumbs more ServerAddress vs. string parameters.

### DIFF
--- a/inmem_transport.go
+++ b/inmem_transport.go
@@ -9,15 +9,15 @@ import (
 
 // NewInmemAddr returns a new in-memory addr with
 // a randomly generate UUID as the ID.
-func NewInmemAddr() string {
-	return generateUUID()
+func NewInmemAddr() ServerAddress {
+	return ServerAddress(generateUUID())
 }
 
 // inmemPipeline is used to pipeline requests for the in-mem transport.
 type inmemPipeline struct {
 	trans    *InmemTransport
 	peer     *InmemTransport
-	peerAddr string
+	peerAddr ServerAddress
 
 	doneCh       chan AppendFuture
 	inprogressCh chan *inmemPipelineInflight
@@ -37,22 +37,22 @@ type inmemPipelineInflight struct {
 type InmemTransport struct {
 	sync.RWMutex
 	consumerCh chan RPC
-	localAddr  string
-	peers      map[string]*InmemTransport
+	localAddr  ServerAddress
+	peers      map[ServerAddress]*InmemTransport
 	pipelines  []*inmemPipeline
 	timeout    time.Duration
 }
 
 // NewInmemTransport is used to initialize a new transport
 // and generates a random local address if none is specified
-func NewInmemTransport(addr string) (string, *InmemTransport) {
-	if addr == "" {
+func NewInmemTransport(addr ServerAddress) (ServerAddress, *InmemTransport) {
+	if string(addr) == "" {
 		addr = NewInmemAddr()
 	}
 	trans := &InmemTransport{
 		consumerCh: make(chan RPC, 16),
 		localAddr:  addr,
-		peers:      make(map[string]*InmemTransport),
+		peers:      make(map[ServerAddress]*InmemTransport),
 		timeout:    50 * time.Millisecond,
 	}
 	return addr, trans
@@ -69,13 +69,13 @@ func (i *InmemTransport) Consumer() <-chan RPC {
 }
 
 // LocalAddr implements the Transport interface.
-func (i *InmemTransport) LocalAddr() string {
+func (i *InmemTransport) LocalAddr() ServerAddress {
 	return i.localAddr
 }
 
 // AppendEntriesPipeline returns an interface that can be used to pipeline
 // AppendEntries requests.
-func (i *InmemTransport) AppendEntriesPipeline(target string) (AppendPipeline, error) {
+func (i *InmemTransport) AppendEntriesPipeline(target ServerAddress) (AppendPipeline, error) {
 	i.RLock()
 	peer, ok := i.peers[target]
 	i.RUnlock()
@@ -90,7 +90,7 @@ func (i *InmemTransport) AppendEntriesPipeline(target string) (AppendPipeline, e
 }
 
 // AppendEntries implements the Transport interface.
-func (i *InmemTransport) AppendEntries(target string, args *AppendEntriesRequest, resp *AppendEntriesResponse) error {
+func (i *InmemTransport) AppendEntries(target ServerAddress, args *AppendEntriesRequest, resp *AppendEntriesResponse) error {
 	rpcResp, err := i.makeRPC(target, args, nil, i.timeout)
 	if err != nil {
 		return err
@@ -103,7 +103,7 @@ func (i *InmemTransport) AppendEntries(target string, args *AppendEntriesRequest
 }
 
 // RequestVote implements the Transport interface.
-func (i *InmemTransport) RequestVote(target string, args *RequestVoteRequest, resp *RequestVoteResponse) error {
+func (i *InmemTransport) RequestVote(target ServerAddress, args *RequestVoteRequest, resp *RequestVoteResponse) error {
 	rpcResp, err := i.makeRPC(target, args, nil, i.timeout)
 	if err != nil {
 		return err
@@ -116,7 +116,7 @@ func (i *InmemTransport) RequestVote(target string, args *RequestVoteRequest, re
 }
 
 // InstallSnapshot implements the Transport interface.
-func (i *InmemTransport) InstallSnapshot(target string, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error {
+func (i *InmemTransport) InstallSnapshot(target ServerAddress, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error {
 	rpcResp, err := i.makeRPC(target, args, data, 10*i.timeout)
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (i *InmemTransport) InstallSnapshot(target string, args *InstallSnapshotReq
 	return nil
 }
 
-func (i *InmemTransport) makeRPC(target string, args interface{}, r io.Reader, timeout time.Duration) (rpcResp RPCResponse, err error) {
+func (i *InmemTransport) makeRPC(target ServerAddress, args interface{}, r io.Reader, timeout time.Duration) (rpcResp RPCResponse, err error) {
 	i.RLock()
 	peer, ok := i.peers[target]
 	i.RUnlock()
@@ -158,21 +158,19 @@ func (i *InmemTransport) makeRPC(target string, args interface{}, r io.Reader, t
 	return
 }
 
-// EncodePeer implements the Transport interface. It uses the UUID as the
-// address directly.
-func (i *InmemTransport) EncodePeer(p string) []byte {
+// EncodePeer implements the Transport interface.
+func (i *InmemTransport) EncodePeer(p ServerAddress) []byte {
 	return []byte(p)
 }
 
-// DecodePeer implements the Transport interface. It wraps the UUID in an
-// InmemAddr.
-func (i *InmemTransport) DecodePeer(buf []byte) string {
-	return string(buf)
+// DecodePeer implements the Transport interface.
+func (i *InmemTransport) DecodePeer(buf []byte) ServerAddress {
+	return ServerAddress(buf)
 }
 
 // Connect is used to connect this transport to another transport for
 // a given peer name. This allows for local routing.
-func (i *InmemTransport) Connect(peer string, t Transport) {
+func (i *InmemTransport) Connect(peer ServerAddress, t Transport) {
 	trans := t.(*InmemTransport)
 	i.Lock()
 	defer i.Unlock()
@@ -180,7 +178,7 @@ func (i *InmemTransport) Connect(peer string, t Transport) {
 }
 
 // Disconnect is used to remove the ability to route to a given peer.
-func (i *InmemTransport) Disconnect(peer string) {
+func (i *InmemTransport) Disconnect(peer ServerAddress) {
 	i.Lock()
 	defer i.Unlock()
 	delete(i.peers, peer)
@@ -202,7 +200,7 @@ func (i *InmemTransport) Disconnect(peer string) {
 func (i *InmemTransport) DisconnectAll() {
 	i.Lock()
 	defer i.Unlock()
-	i.peers = make(map[string]*InmemTransport)
+	i.peers = make(map[ServerAddress]*InmemTransport)
 
 	// Handle pipelines
 	for _, pipeline := range i.pipelines {
@@ -217,7 +215,7 @@ func (i *InmemTransport) Close() error {
 	return nil
 }
 
-func newInmemPipeline(trans *InmemTransport, peer *InmemTransport, addr string) *inmemPipeline {
+func newInmemPipeline(trans *InmemTransport, peer *InmemTransport, addr ServerAddress) *inmemPipeline {
 	i := &inmemPipeline{
 		trans:        trans,
 		peer:         peer,

--- a/integ_test.go
+++ b/integ_test.go
@@ -238,8 +238,8 @@ func TestRaft_Integ(t *testing.T) {
 	}
 
 	// Remove the old nodes
-	NoErr(WaitFuture(leader.raft.RemovePeer(string(rm1.raft.localAddr)), t), t)
-	NoErr(WaitFuture(leader.raft.RemovePeer(string(rm2.raft.localAddr)), t), t)
+	NoErr(WaitFuture(leader.raft.RemovePeer(rm1.raft.localAddr), t), t)
+	NoErr(WaitFuture(leader.raft.RemovePeer(rm2.raft.localAddr), t), t)
 
 	// Shoot the leader
 	env1.Release()

--- a/integ_test.go
+++ b/integ_test.go
@@ -74,6 +74,17 @@ func MakeRaft(t *testing.T, conf *Config) *RaftEnv {
 	}
 	env.trans = trans
 
+	var configuration Configuration
+	configuration.Servers = append(configuration.Servers, Server{
+		Suffrage: Voter,
+		ID:       ServerID(trans.LocalAddr()),
+		Address:  trans.LocalAddr(),
+	})
+	err = BootstrapCluster(conf, stable, stable, snap, configuration)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	log.Printf("[INFO] Starting node at %v", trans.LocalAddr())
 	raft, err := NewRaft(conf, env.fsm, stable, stable, snap, trans)
 	if err != nil {

--- a/net_transport.go
+++ b/net_transport.go
@@ -56,7 +56,7 @@ is not known if there is an error.
 
 */
 type NetworkTransport struct {
-	connPool     map[string][]*netConn
+	connPool     map[ServerAddress][]*netConn
 	connPoolLock sync.Mutex
 
 	consumeCh chan RPC
@@ -84,11 +84,11 @@ type StreamLayer interface {
 	net.Listener
 
 	// Dial is used to create a new outgoing connection
-	Dial(address string, timeout time.Duration) (net.Conn, error)
+	Dial(address ServerAddress, timeout time.Duration) (net.Conn, error)
 }
 
 type netConn struct {
-	target string
+	target ServerAddress
 	conn   net.Conn
 	r      *bufio.Reader
 	w      *bufio.Writer
@@ -142,7 +142,7 @@ func NewNetworkTransportWithLogger(
 		logger = log.New(os.Stderr, "", log.LstdFlags)
 	}
 	trans := &NetworkTransport{
-		connPool:     make(map[string][]*netConn),
+		connPool:     make(map[ServerAddress][]*netConn),
 		consumeCh:    make(chan RPC),
 		logger:       logger,
 		maxPool:      maxPool,
@@ -183,8 +183,8 @@ func (n *NetworkTransport) Consumer() <-chan RPC {
 }
 
 // LocalAddr implements the Transport interface.
-func (n *NetworkTransport) LocalAddr() string {
-	return n.stream.Addr().String()
+func (n *NetworkTransport) LocalAddr() ServerAddress {
+	return ServerAddress(n.stream.Addr().String())
 }
 
 // IsShutdown is used to check if the transport is shutdown.
@@ -198,7 +198,7 @@ func (n *NetworkTransport) IsShutdown() bool {
 }
 
 // getExistingConn is used to grab a pooled connection.
-func (n *NetworkTransport) getPooledConn(target string) *netConn {
+func (n *NetworkTransport) getPooledConn(target ServerAddress) *netConn {
 	n.connPoolLock.Lock()
 	defer n.connPoolLock.Unlock()
 
@@ -215,7 +215,7 @@ func (n *NetworkTransport) getPooledConn(target string) *netConn {
 }
 
 // getConn is used to get a connection from the pool.
-func (n *NetworkTransport) getConn(target string) (*netConn, error) {
+func (n *NetworkTransport) getConn(target ServerAddress) (*netConn, error) {
 	// Check for a pooled conn
 	if conn := n.getPooledConn(target); conn != nil {
 		return conn, nil
@@ -260,7 +260,7 @@ func (n *NetworkTransport) returnConn(conn *netConn) {
 
 // AppendEntriesPipeline returns an interface that can be used to pipeline
 // AppendEntries requests.
-func (n *NetworkTransport) AppendEntriesPipeline(target string) (AppendPipeline, error) {
+func (n *NetworkTransport) AppendEntriesPipeline(target ServerAddress) (AppendPipeline, error) {
 	// Get a connection
 	conn, err := n.getConn(target)
 	if err != nil {
@@ -272,17 +272,17 @@ func (n *NetworkTransport) AppendEntriesPipeline(target string) (AppendPipeline,
 }
 
 // AppendEntries implements the Transport interface.
-func (n *NetworkTransport) AppendEntries(target string, args *AppendEntriesRequest, resp *AppendEntriesResponse) error {
+func (n *NetworkTransport) AppendEntries(target ServerAddress, args *AppendEntriesRequest, resp *AppendEntriesResponse) error {
 	return n.genericRPC(target, rpcAppendEntries, args, resp)
 }
 
 // RequestVote implements the Transport interface.
-func (n *NetworkTransport) RequestVote(target string, args *RequestVoteRequest, resp *RequestVoteResponse) error {
+func (n *NetworkTransport) RequestVote(target ServerAddress, args *RequestVoteRequest, resp *RequestVoteResponse) error {
 	return n.genericRPC(target, rpcRequestVote, args, resp)
 }
 
 // genericRPC handles a simple request/response RPC.
-func (n *NetworkTransport) genericRPC(target string, rpcType uint8, args interface{}, resp interface{}) error {
+func (n *NetworkTransport) genericRPC(target ServerAddress, rpcType uint8, args interface{}, resp interface{}) error {
 	// Get a conn
 	conn, err := n.getConn(target)
 	if err != nil {
@@ -308,7 +308,7 @@ func (n *NetworkTransport) genericRPC(target string, rpcType uint8, args interfa
 }
 
 // InstallSnapshot implements the Transport interface.
-func (n *NetworkTransport) InstallSnapshot(target string, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error {
+func (n *NetworkTransport) InstallSnapshot(target ServerAddress, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error {
 	// Get a conn, always close for InstallSnapshot
 	conn, err := n.getConn(target)
 	if err != nil {
@@ -346,13 +346,13 @@ func (n *NetworkTransport) InstallSnapshot(target string, args *InstallSnapshotR
 }
 
 // EncodePeer implements the Transport interface.
-func (n *NetworkTransport) EncodePeer(p string) []byte {
+func (n *NetworkTransport) EncodePeer(p ServerAddress) []byte {
 	return []byte(p)
 }
 
 // DecodePeer implements the Transport interface.
-func (n *NetworkTransport) DecodePeer(buf []byte) string {
-	return string(buf)
+func (n *NetworkTransport) DecodePeer(buf []byte) ServerAddress {
+	return ServerAddress(buf)
 }
 
 // listen is used to handling incoming connections.

--- a/observer.go
+++ b/observer.go
@@ -10,11 +10,6 @@ type Observation struct {
 	Data interface{}
 }
 
-// LeaderObservation is used for the data when leadership changes.
-type LeaderObservation struct {
-	leader string
-}
-
 // nextObserverId is used to provide a unique ID for each observer to aid in
 // deregistration.
 var nextObserverId uint64

--- a/raft.go
+++ b/raft.go
@@ -363,12 +363,8 @@ func (r *Raft) Leader() ServerAddress {
 // setLeader is used to modify the current leader of the cluster
 func (r *Raft) setLeader(leader ServerAddress) {
 	r.leaderLock.Lock()
-	oldLeader := r.leader
 	r.leader = leader
 	r.leaderLock.Unlock()
-	if oldLeader != leader {
-		r.observe(LeaderObservation{leader: string(leader)})
-	}
 }
 
 // Apply is used to apply a command to the FSM in a highly consistent

--- a/raft.go
+++ b/raft.go
@@ -270,9 +270,8 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	localAddr := ServerAddress(trans.LocalAddr())
 	localID := conf.LocalID
 	if localID == "" {
-		logger.Printf("[WARN] raft: No server ID given, using network address: %v",
+		logger.Printf("[WARN] raft: No server ID given, using network address: %v. This default will be removed in the future. Set server ID explicitly in config.",
 			localAddr)
-		logger.Printf("[WARN] raft: This default will be removed in the future. Set server ID explicitly in Config")
 		localID = ServerID(localAddr)
 	}
 

--- a/raft_test.go
+++ b/raft_test.go
@@ -1250,7 +1250,10 @@ func TestRaft_SnapshotRestore(t *testing.T) {
 // TODO: Need a test that has a previous format Snapshot and check that it can be read/installed on the new code.
 
 func TestRaft_SnapshotRestore_PeerChange(t *testing.T) {
-	return // TODO: fix broken test
+	// TODO - Fix broken test. This needs a story about how we recover and
+	// manually let the operator adjust the quorum before we can proceed.
+	return
+
 	// Make the cluster
 	conf := inmemConfig(t)
 	conf.TrailingLogs = 10

--- a/raft_test.go
+++ b/raft_test.go
@@ -1132,40 +1132,6 @@ func TestRaft_RemoveLeader_NoShutdown(t *testing.T) {
 	c.EnsureSame(t)
 }
 
-func TestRaft_RemoveLeader_SplitCluster(t *testing.T) {
-	return // TODO: fix broken test
-	// Enable operation after a remove
-	conf := inmemConfig(t)
-	conf.ShutdownOnRemove = false
-
-	// Make a cluster
-	c := MakeCluster(3, t, conf)
-	defer c.Close()
-
-	// Get the leader
-	c.Followers()
-	leader := c.Leader()
-
-	// Remove the leader
-	leader.RemovePeer(leader.localAddr)
-
-	// Wait until we have 2 leaders
-	limit := time.Now().Add(c.longstopTimeout)
-	var leaders []*Raft
-	for time.Now().Before(limit) && len(leaders) != 2 {
-		c.WaitEvent(nil, c.conf.CommitTimeout)
-		leaders = c.GetInState(Leader)
-	}
-	if len(leaders) != 2 {
-		c.FailNowf("[ERR] expected two leader: %v", leaders)
-	}
-
-	// Old leader should have no peers
-	if len(leader.configurations.latest.Servers) != 1 {
-		c.FailNowf("[ERR] leader should have no peers")
-	}
-}
-
 func TestRaft_AddKnownPeer(t *testing.T) {
 	// Make a cluster
 	c := MakeCluster(3, t, nil)

--- a/replication.go
+++ b/replication.go
@@ -183,7 +183,7 @@ START:
 
 	// Make the RPC call
 	start = time.Now()
-	if err := r.trans.AppendEntries(string(s.peer.Address), &req, &resp); err != nil {
+	if err := r.trans.AppendEntries(s.peer.Address, &req, &resp); err != nil {
 		r.logger.Printf("[ERR] raft: Failed to AppendEntries to %v: %v", s.peer, err)
 		s.failures++
 		return
@@ -276,7 +276,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 	// Setup the request
 	req := InstallSnapshotRequest{
 		Term:               s.currentTerm,
-		Leader:             r.trans.EncodePeer(string(r.localAddr)),
+		Leader:             r.trans.EncodePeer(r.localAddr),
 		LastLogIndex:       meta.Index,
 		LastLogTerm:        meta.Term,
 		Peers:              meta.Peers,
@@ -288,7 +288,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 	// Make the call
 	start := time.Now()
 	var resp InstallSnapshotResponse
-	if err := r.trans.InstallSnapshot(string(s.peer.Address), &req, &resp, snapshot); err != nil {
+	if err := r.trans.InstallSnapshot(s.peer.Address, &req, &resp, snapshot); err != nil {
 		r.logger.Printf("[ERR] raft: Failed to install snapshot %v: %v", snapID, err)
 		s.failures++
 		return false, err
@@ -329,7 +329,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 	var failures uint64
 	req := AppendEntriesRequest{
 		Term:   s.currentTerm,
-		Leader: r.trans.EncodePeer(string(r.localAddr)),
+		Leader: r.trans.EncodePeer(r.localAddr),
 	}
 	var resp AppendEntriesResponse
 	for {
@@ -342,7 +342,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 		}
 
 		start := time.Now()
-		if err := r.trans.AppendEntries(string(s.peer.Address), &req, &resp); err != nil {
+		if err := r.trans.AppendEntries(s.peer.Address, &req, &resp); err != nil {
 			r.logger.Printf("[ERR] raft: Failed to heartbeat to %v: %v", s.peer.Address, err)
 			failures++
 			select {
@@ -364,7 +364,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 // back to the standard replication which can handle more complex situations.
 func (r *Raft) pipelineReplicate(s *followerReplication) error {
 	// Create a new pipeline
-	pipeline, err := r.trans.AppendEntriesPipeline(string(s.peer.Address))
+	pipeline, err := r.trans.AppendEntriesPipeline(s.peer.Address)
 	if err != nil {
 		return err
 	}
@@ -472,7 +472,7 @@ func (r *Raft) pipelineDecode(s *followerReplication, p AppendPipeline, stopCh, 
 // setupAppendEntries is used to setup an append entries request.
 func (r *Raft) setupAppendEntries(s *followerReplication, req *AppendEntriesRequest, nextIndex, lastIndex uint64) error {
 	req.Term = s.currentTerm
-	req.Leader = r.trans.EncodePeer(string(r.localAddr))
+	req.Leader = r.trans.EncodePeer(r.localAddr)
 	req.LeaderCommitIndex = r.getCommitIndex()
 	if err := r.setPreviousLog(req, nextIndex); err != nil {
 		return err

--- a/tcp_transport.go
+++ b/tcp_transport.go
@@ -81,8 +81,8 @@ func newTCPTransport(bindAddr string,
 }
 
 // Dial implements the StreamLayer interface.
-func (t *TCPStreamLayer) Dial(address string, timeout time.Duration) (net.Conn, error) {
-	return net.DialTimeout("tcp", address, timeout)
+func (t *TCPStreamLayer) Dial(address ServerAddress, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("tcp", string(address), timeout)
 }
 
 // Accept implements the net.Listener interface.

--- a/transport.go
+++ b/transport.go
@@ -31,27 +31,27 @@ type Transport interface {
 	Consumer() <-chan RPC
 
 	// LocalAddr is used to return our local address to distinguish from our peers.
-	LocalAddr() string
+	LocalAddr() ServerAddress
 
 	// AppendEntriesPipeline returns an interface that can be used to pipeline
 	// AppendEntries requests.
-	AppendEntriesPipeline(target string) (AppendPipeline, error)
+	AppendEntriesPipeline(target ServerAddress) (AppendPipeline, error)
 
 	// AppendEntries sends the appropriate RPC to the target node.
-	AppendEntries(target string, args *AppendEntriesRequest, resp *AppendEntriesResponse) error
+	AppendEntries(target ServerAddress, args *AppendEntriesRequest, resp *AppendEntriesResponse) error
 
 	// RequestVote sends the appropriate RPC to the target node.
-	RequestVote(target string, args *RequestVoteRequest, resp *RequestVoteResponse) error
+	RequestVote(target ServerAddress, args *RequestVoteRequest, resp *RequestVoteResponse) error
 
 	// InstallSnapshot is used to push a snapshot down to a follower. The data is read from
 	// the ReadCloser and streamed to the client.
-	InstallSnapshot(target string, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error
+	InstallSnapshot(target ServerAddress, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error
 
-	// EncodePeer is used to serialize a peer name.
-	EncodePeer(string) []byte
+	// EncodePeer is used to serialize a peer's address.
+	EncodePeer(ServerAddress) []byte
 
-	// DecodePeer is used to deserialize a peer name.
-	DecodePeer([]byte) string
+	// DecodePeer is used to deserialize a peer's address.
+	DecodePeer([]byte) ServerAddress
 
 	// SetHeartbeatHandler is used to setup a heartbeat handler
 	// as a fast-pass. This is to avoid head-of-line blocking from
@@ -79,9 +79,9 @@ type LoopbackTransport interface {
 // disconnection. Unless the transport is a loopback transport, the transport specified to
 // "Connect" is likely to be nil.
 type WithPeers interface {
-	Connect(peer string, t Transport) // Connect a peer
-	Disconnect(peer string)           // Disconnect a given peer
-	DisconnectAll()                   // Disconnect all peers, possibly to reconnect them later
+	Connect(peer ServerAddress, t Transport) // Connect a peer
+	Disconnect(peer ServerAddress)           // Disconnect a given peer
+	DisconnectAll()                          // Disconnect all peers, possibly to reconnect them later
 }
 
 // AppendPipeline is used for pipelining AppendEntries requests. It is used

--- a/transport_test.go
+++ b/transport_test.go
@@ -12,7 +12,7 @@ const (
 	TT_MAX
 )
 
-func NewTestTransport(ttype int, addr string) (string, LoopbackTransport) {
+func NewTestTransport(ttype int, addr ServerAddress) (ServerAddress, LoopbackTransport) {
 	switch ttype {
 	case TT_INMEM:
 		addr, lt := NewInmemTransport(addr)


### PR DESCRIPTION
This cleans up a couple of todo items and plumbs `ServerAddress` into more places for extra clarity. I decided that since the fix is trivial (just a cast to support old code) that it was worth breaking the interface to make the code super clear.

/cc @ongardie 

Mentioning #84.