### PR TITLE
doc fixes, goroutine WaitGroup, export Leader field

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,15 +10,17 @@ import (
 // Config provides any necessary configuration to
 // the Raft server
 type Config struct {
-	// Time in follower state without a leader before we attempt an election.
+	// HeartbeatTimeout specifies the time in follower state without
+	// a leader before we attempt an election.
 	HeartbeatTimeout time.Duration
 
-	// Time in candidate state without a leader before we attempt an election.
+	// ElectionTimeout specifies the time in candidate state without
+	// a leader before we attempt an election.
 	ElectionTimeout time.Duration
 
-	// Time without an Apply() operation before we heartbeat to ensure
-	// a timely commit. Due to random staggering, may be delayed as much as
-	// 2x this value.
+	// CommitTimeout controls the time without an Apply() operation
+	// before we heartbeat to ensure a timely commit. Due to random
+	// staggering, may be delayed as much as 2x this value.
 	CommitTimeout time.Duration
 
 	// MaxAppendEntries controls the maximum number of append entries

--- a/fsm.go
+++ b/fsm.go
@@ -8,6 +8,9 @@ import (
 // clients to make use of the replicated log.
 type FSM interface {
 	// Apply log is invoked once a log entry is committed.
+	// It returns a value which will be made available in the
+	// ApplyFuture returned by Raft.Apply method if that
+	// method was called on the same Raft node as the FSM.
 	Apply(*Log) interface{}
 
 	// Snapshot is used to support log compaction. This call should

--- a/future_test.go
+++ b/future_test.go
@@ -1,0 +1,42 @@
+package raft
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDeferFutureSuccess(t *testing.T) {
+	var f deferError
+	f.init()
+	f.respond(nil)
+	if err := f.Error(); err != nil {
+		t.Fatalf("unexpected error result; got %#v want nil", err)
+	}
+	if err := f.Error(); err != nil {
+		t.Fatalf("unexpected error result; got %#v want nil", err)
+	}
+}
+
+func TestDeferFutureError(t *testing.T) {
+	want := errors.New("x")
+	var f deferError
+	f.init()
+	f.respond(want)
+	if got := f.Error(); got != want {
+		t.Fatalf("unexpected error result; got %#v want %#v", got, want)
+	}
+	if got := f.Error(); got != want {
+		t.Fatalf("unexpected error result; got %#v want %#v", got, want)
+	}
+}
+
+func TestDeferFutureConcurrent(t *testing.T) {
+	// Food for the race detector.
+	want := errors.New("x")
+	var f deferError
+	f.init()
+	go f.respond(want)
+	if got := f.Error(); got != want {
+		t.Errorf("unexpected error result; got %#v want %#v", got, want)
+	}
+}

--- a/log.go
+++ b/log.go
@@ -27,10 +27,17 @@ const (
 // Log entries are replicated to all members of the Raft cluster
 // and form the heart of the replicated state machine.
 type Log struct {
+	// Index holds the index of the log entry.
 	Index uint64
-	Term  uint64
-	Type  LogType
-	Data  []byte
+
+	// Term holds the election term of the log entry.
+	Term uint64
+
+	// Type holds the type of the log entry.
+	Type LogType
+
+	// Data holds the log entry's type-specific data.
+	Data []byte
 
 	// peer is not exported since it is not transmitted, only used
 	// internally to construct the Data field.
@@ -40,21 +47,21 @@ type Log struct {
 // LogStore is used to provide an interface for storing
 // and retrieving logs in a durable fashion.
 type LogStore interface {
-	// Returns the first index written. 0 for no entries.
+	// FirstIndex returns the first index written. 0 for no entries.
 	FirstIndex() (uint64, error)
 
-	// Returns the last index written. 0 for no entries.
+	// LastIndex returns the last index written. 0 for no entries.
 	LastIndex() (uint64, error)
 
-	// Gets a log entry at a given index.
+	// GetLog gets a log entry at a given index.
 	GetLog(index uint64, log *Log) error
 
-	// Stores a log entry.
+	// StoreLog stores a log entry.
 	StoreLog(log *Log) error
 
-	// Stores multiple log entries.
+	// StoreLogs stores multiple log entries.
 	StoreLogs(logs []*Log) error
 
-	// Deletes a range of log entries. The range is inclusive.
+	// DeleteRange deletes a range of log entries. The range is inclusive.
 	DeleteRange(min, max uint64) error
 }

--- a/observer.go
+++ b/observer.go
@@ -6,21 +6,25 @@ import (
 
 // Observation is sent along the given channel to observers when an event occurs.
 type Observation struct {
+	// Raft holds the Raft instance generating the observation.
 	Raft *Raft
+	// Data holds observation-specific data. Possible types are
+	// *RequestVoteRequest, RaftState and LeaderObservation.
 	Data interface{}
 }
 
-// LeaderObservation is used for the data when leadership changes.
+// LeaderObservation is used in Observation.Data when leadership changes.
 type LeaderObservation struct {
-	leader string
+	Leader string
 }
 
 // nextObserverId is used to provide a unique ID for each observer to aid in
 // deregistration.
 var nextObserverId uint64
 
-// FilterFn is a function that can be registered in order to filter observations
-// by returning false.
+// FilterFn is a function that can be registered in order to filter observations.
+// The function reports whether the observation should be included - if
+// it returns false, the observation will be filtered out.
 type FilterFn func(o *Observation) bool
 
 // Observer describes what to do with a given observation.
@@ -44,8 +48,13 @@ type Observer struct {
 	numDropped  uint64
 }
 
-// Create a new observer with the specified channel, blocking behavior, and
-// filter (filter can be nil).
+// NewObserver creates a new observer that can be registered
+// to make observations on a Raft instance. Observations
+// will be sent on the given channel if they satisfy the
+// given filter.
+//
+// If blocking is true, the observer will block when it can't
+// send on the channel, otherwise it may discard events.
 func NewObserver(channel chan Observation, blocking bool, filter FilterFn) *Observer {
 	return &Observer{
 		channel:  channel,
@@ -65,21 +74,21 @@ func (or *Observer) GetNumDropped() uint64 {
 	return atomic.LoadUint64(&or.numDropped)
 }
 
-// Register a new observer.
+// RegisterObserver registers a new observer.
 func (r *Raft) RegisterObserver(or *Observer) {
 	r.observersLock.Lock()
 	defer r.observersLock.Unlock()
 	r.observers[or.id] = or
 }
 
-// Deregister an observer.
+// DeregisterObserver deregisters an observer.
 func (r *Raft) DeregisterObserver(or *Observer) {
 	r.observersLock.Lock()
 	defer r.observersLock.Unlock()
 	delete(r.observers, or.id)
 }
 
-// Send an observation to every observer.
+// observe sends an observation to every observer.
 func (r *Raft) observe(o interface{}) {
 	// In general observers should not block. But in any case this isn't
 	// disastrous as we only hold a read lock, which merely prevents

--- a/raft.go
+++ b/raft.go
@@ -277,7 +277,7 @@ func (r *Raft) setLeader(leader string) {
 	r.leader = leader
 	r.leaderLock.Unlock()
 	if oldLeader != leader {
-		r.observe(LeaderObservation{leader: leader})
+		r.observe(LeaderObservation{Leader: leader})
 	}
 }
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -16,7 +16,7 @@ type SnapshotMeta struct {
 // SnapshotStore interface is used to allow for flexible implementations
 // of snapshot storage and retrieval. For example, a client could implement
 // a shared state store such as S3, allowing new nodes to restore snapshots
-// without steaming from the leader.
+// without streaming from the leader.
 type SnapshotStore interface {
 	// Create is used to begin a snapshot at a given index and term,
 	// with the current peer set already encoded.


### PR DESCRIPTION
Some minor doc fixes to make comments more Go idiomatic
and alter/add some things that seemed unclear to me
when writing a proof-of-concept FSM.

Add a comment in deferError to clarify how things
work with a nil error - at first glance it looks like
a bug (also add some explicit unit tests of deferFuture).

Track the running goroutines with a WaitGroup so we
don't need to actively poll the goroutine count.

Export the Leader field from LeaderObservation, making the
observation value more useful.