### PR TITLE
Split apart and test appendConfigurationEntry

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -20,6 +20,18 @@ const (
 	Staging
 )
 
+func (s ServerSuffrage) String() string {
+	switch s {
+	case Voter:
+		return "Voter"
+	case Nonvoter:
+		return "Nonvoter"
+	case Staging:
+		return "Staging"
+	}
+	return "ServerSuffrage"
+}
+
 // ServerID is a unique string identifying a server for all time.
 type ServerID string
 

--- a/future.go
+++ b/future.go
@@ -74,52 +74,12 @@ func (d *deferError) respond(err error) {
 	d.responded = true
 }
 
-// ConfigurationChangeCommand is the different ways to change the cluster
-// configuration.
-type ConfigurationChangeCommand uint8
-
-const (
-	// AddStaging makes a server Staging unless its Voter.
-	AddStaging ConfigurationChangeCommand = iota
-	// AddNonvoter makes a server Nonvoter unless its Staging or Voter.
-	AddNonvoter
-	// DemoteVoter makes a server Nonvoter unless its absent.
-	DemoteVoter
-	// RemoveServer removes a server entirely from the cluster membership.
-	RemoveServer
-	// Promote is created automatically by a leader; it turns a Staging server
-	// into a Voter.
-	Promote
-)
-
-func (c ConfigurationChangeCommand) String() string {
-	switch c {
-	case AddStaging:
-		return "AddStaging"
-	case AddNonvoter:
-		return "AddNonvoter"
-	case DemoteVoter:
-		return "DemoteVoter"
-	case RemoveServer:
-		return "RemoveServer"
-	case Promote:
-		return "Promote"
-	}
-	return "ConfigurationChangeCommand"
-}
-
 // There are several types of requests that cause a configuration entry to
 // be appended to the log. These are encoded here for leaderLoop() to process.
 // This is internal to a single server.
 type configurationChangeFuture struct {
 	logFuture
-	command       ConfigurationChangeCommand
-	serverID      ServerID
-	serverAddress ServerAddress // only present for AddStaging, AddNonvoter
-	// prevIndex, if nonzero, is the index of the only configuration upon which
-	// this change may be applied; if another configuration entry has been
-	// added in the meantime, this request will fail.
-	prevIndex uint64
+	req configurationChangeRequest
 }
 
 // logFuture is used to apply a log entry and waits until

--- a/future.go
+++ b/future.go
@@ -92,6 +92,22 @@ const (
 	Promote
 )
 
+func (c ConfigurationChangeCommand) String() string {
+	switch c {
+	case AddStaging:
+		return "AddStaging"
+	case AddNonvoter:
+		return "AddNonvoter"
+	case DemoteVoter:
+		return "DemoteVoter"
+	case RemoveServer:
+		return "RemoveServer"
+	case Promote:
+		return "Promote"
+	}
+	return "ConfigurationChangeCommand"
+}
+
 // There are several types of requests that cause a configuration entry to
 // be appended to the log. These are encoded here for leaderLoop() to process.
 // This is internal to a single server.

--- a/raft.go
+++ b/raft.go
@@ -980,7 +980,7 @@ func (r *Raft) runLeader() {
 // it'll instruct the replication routines to try to replicate to the current
 // index.
 func (r *Raft) startStopReplication() {
-	inConfig := make(map[ServerID]bool, len(r.leaderState.replState))
+	inConfig := make(map[ServerID]bool, len(r.configurations.latest.Servers))
 	lastIdx := r.getLastIndex()
 
 	// Start replication goroutines that need starting
@@ -989,8 +989,8 @@ func (r *Raft) startStopReplication() {
 			continue
 		}
 		inConfig[server.ID] = true
-		r.logger.Printf("[INFO] raft: Added peer %v, starting replication", server)
-		if _, present := r.leaderState.replState[server.ID]; !present {
+		if _, ok := r.leaderState.replState[server.ID]; !ok {
+			r.logger.Printf("[INFO] raft: Added peer %v, starting replication", server.ID)
 			s := &followerReplication{
 				peer:        server,
 				commitment:  r.leaderState.commitment,

--- a/raft_test.go
+++ b/raft_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -981,6 +982,180 @@ func TestRaft_ApplyConcurrent_Timeout(t *testing.T) {
 		c.WaitEvent(nil, c.propagateTimeout)
 	}
 	c.FailNowf("[ERR] Timeout waiting to detect apply timeouts")
+}
+
+func TestRaft_nextConfiguration_prevIndex(t *testing.T) {
+	// Stale prevIndex.
+	future := &configurationChangeFuture{
+		command:       AddStaging,
+		serverID:      ServerID("id1"),
+		serverAddress: ServerAddress("addr1"),
+		prevIndex:     1,
+	}
+	future.init()
+	next := nextConfiguration(Configuration{}, 2, future)
+	if len(next.Servers) > 0 || !future.responded ||
+		!strings.Contains(future.Error().Error(), "changed") {
+		t.Fatalf("nextConfiguration should have failed due to intervening configuration change")
+	}
+
+	// Current prevIndex.
+	future = &configurationChangeFuture{
+		command:       AddStaging,
+		serverID:      ServerID("id2"),
+		serverAddress: ServerAddress("addr2"),
+		prevIndex:     2,
+	}
+	future.init()
+	next = nextConfiguration(Configuration{}, 2, future)
+	if len(next.Servers) == 0 || future.responded {
+		t.Fatalf("nextConfiguration should have succeeded, got %v", future.Error())
+	}
+
+	// Zero prevIndex.
+	future = &configurationChangeFuture{
+		command:       AddStaging,
+		serverID:      ServerID("id3"),
+		serverAddress: ServerAddress("addr3"),
+		prevIndex:     0,
+	}
+	future.init()
+	next = nextConfiguration(Configuration{}, 2, future)
+	if len(next.Servers) == 0 || future.responded {
+		t.Fatalf("nextConfiguration should have succeeded, got %v", future.Error())
+	}
+}
+
+func TestRaft_nextConfiguration_checkConfiguration(t *testing.T) {
+	future := &configurationChangeFuture{
+		command:       AddNonvoter,
+		serverID:      ServerID("id1"),
+		serverAddress: ServerAddress("addr1"),
+	}
+	future.init()
+	next := nextConfiguration(Configuration{}, 1, future)
+	if len(next.Servers) > 0 || !future.responded ||
+		!strings.Contains(future.Error().Error(), "at least one voter") {
+		t.Fatalf("nextConfiguration should have failed for not having a voter")
+	}
+}
+
+var singleServer = Configuration{
+	Servers: []Server{
+		Server{
+			Suffrage: Voter,
+			ID:       ServerID("id1"),
+			Address:  ServerAddress("addr1x"),
+		},
+	},
+}
+
+var oneOfEach = Configuration{
+	Servers: []Server{
+		Server{
+			Suffrage: Voter,
+			ID:       ServerID("id1"),
+			Address:  ServerAddress("addr1x"),
+		},
+		Server{
+			Suffrage: Staging,
+			ID:       ServerID("id2"),
+			Address:  ServerAddress("addr2x"),
+		},
+		Server{
+			Suffrage: Nonvoter,
+			ID:       ServerID("id3"),
+			Address:  ServerAddress("addr3x"),
+		},
+	},
+}
+
+var voterPair = Configuration{
+	Servers: []Server{
+		Server{
+			Suffrage: Voter,
+			ID:       ServerID("id1"),
+			Address:  ServerAddress("addr1x"),
+		},
+		Server{
+			Suffrage: Voter,
+			ID:       ServerID("id2"),
+			Address:  ServerAddress("addr2x"),
+		},
+	},
+}
+
+var nextConfigurationTests = []struct {
+	current  Configuration
+	command  ConfigurationChangeCommand
+	serverID int
+	next     string
+}{
+	// AddStaging: was missing.
+	{Configuration{}, AddStaging, 1, "{[{Voter id1 addr1}]}"},
+	{singleServer, AddStaging, 2, "{[{Voter id1 addr1x} {Voter id2 addr2}]}"},
+	// AddStaging: was Voter.
+	{singleServer, AddStaging, 1, "{[{Voter id1 addr1}]}"},
+	// AddStaging: was Staging.
+	{oneOfEach, AddStaging, 2, "{[{Voter id1 addr1x} {Voter id2 addr2} {Nonvoter id3 addr3x}]}"},
+	// AddStaging: was Nonvoter.
+	{oneOfEach, AddStaging, 3, "{[{Voter id1 addr1x} {Staging id2 addr2x} {Voter id3 addr3}]}"},
+
+	// AddNonvoter: was missing.
+	{singleServer, AddNonvoter, 2, "{[{Voter id1 addr1x} {Nonvoter id2 addr2}]}"},
+	// AddNonvoter: was Voter.
+	{singleServer, AddNonvoter, 1, "{[{Voter id1 addr1}]}"},
+	// AddNonvoter: was Staging.
+	{oneOfEach, AddNonvoter, 2, "{[{Voter id1 addr1x} {Staging id2 addr2} {Nonvoter id3 addr3x}]}"},
+	// AddNonvoter: was Nonvoter.
+	{oneOfEach, AddNonvoter, 3, "{[{Voter id1 addr1x} {Staging id2 addr2x} {Nonvoter id3 addr3}]}"},
+
+	// DemoteVoter: was missing.
+	{singleServer, DemoteVoter, 2, "{[{Voter id1 addr1x}]}"},
+	// DemoteVoter: was Voter.
+	{voterPair, DemoteVoter, 2, "{[{Voter id1 addr1x} {Nonvoter id2 addr2x}]}"},
+	// DemoteVoter: was Staging.
+	{oneOfEach, DemoteVoter, 2, "{[{Voter id1 addr1x} {Nonvoter id2 addr2x} {Nonvoter id3 addr3x}]}"},
+	// DemoteVoter: was Nonvoter.
+	{oneOfEach, DemoteVoter, 3, "{[{Voter id1 addr1x} {Staging id2 addr2x} {Nonvoter id3 addr3x}]}"},
+
+	// RemoveServer: was missing.
+	{singleServer, RemoveServer, 2, "{[{Voter id1 addr1x}]}"},
+	// RemoveServer: was Voter.
+	{voterPair, RemoveServer, 2, "{[{Voter id1 addr1x}]}"},
+	// RemoveServer: was Staging.
+	{oneOfEach, RemoveServer, 2, "{[{Voter id1 addr1x} {Nonvoter id3 addr3x}]}"},
+	// RemoveServer: was Nonvoter.
+	{oneOfEach, RemoveServer, 3, "{[{Voter id1 addr1x} {Staging id2 addr2x}]}"},
+
+	// Promote: was missing.
+	{singleServer, Promote, 2, "{[{Voter id1 addr1x}]}"},
+	// Promote: was Voter.
+	{singleServer, Promote, 1, "{[{Voter id1 addr1x}]}"},
+	// Promote: was Staging.
+	{oneOfEach, Promote, 2, "{[{Voter id1 addr1x} {Voter id2 addr2x} {Nonvoter id3 addr3x}]}"},
+	// Promote: was Nonvoter.
+	{oneOfEach, Promote, 3, "{[{Voter id1 addr1x} {Staging id2 addr2x} {Nonvoter id3 addr3x}]}"},
+}
+
+func TestRaft_nextConfiguration_table(t *testing.T) {
+	for i, tt := range nextConfigurationTests {
+		future := &configurationChangeFuture{
+			command:       tt.command,
+			serverID:      ServerID(fmt.Sprintf("id%d", tt.serverID)),
+			serverAddress: ServerAddress(fmt.Sprintf("addr%d", tt.serverID)),
+		}
+		future.init()
+		next := nextConfiguration(tt.current, 1, future)
+		if len(next.Servers) == 0 || future.responded {
+			t.Errorf("nextConfiguration %d should have succeeded, got %v", i, future.Error())
+			continue
+		}
+		if fmt.Sprintf("%v", next) != tt.next {
+			t.Errorf("nextConfiguration %d returned %v, expected %s", i, next, tt.next)
+			continue
+		}
+	}
 }
 
 func TestRaft_JoinNode(t *testing.T) {


### PR DESCRIPTION
This fixes a bug where AddNonvoter would previously demote a server from
Staging to Nonvoter (the intended semantics are no-op in that case).

This is box 14 on James's post- hashicorp/raft#117 checklist on hashicorp/raft#84.