### PR TITLE
Document map fields returned by Stats()

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -468,8 +468,23 @@ func (r *Raft) LastContact() time.Time {
 	return last
 }
 
-// Stats is used to return a map of various internal stats. This should only
-// be used for informative purposes or debugging.
+// Stats is used to return a map of various internal stats. This
+// should only be used for informative purposes or debugging.
+//
+// Keys are: "state", "term", "last_log_index", "last_log_term",
+// "commit_index", "applied_index", "fsm_pending",
+// "last_snapshot_index", "last_snapshot_term", "num_peers" and
+// "last_contact".
+//
+// The value of "state" is a numerical value representing a
+// RaftState const.
+//
+// The value of "last_contact" is either "never" if there
+// has been no contact with a leader, "0" if the node is in the
+// leader state, or the time since last contact with a leader
+// formatted as a string.
+//
+// All other values are uint64s, formatted as strings.
 func (r *Raft) Stats() map[string]string {
 	toString := func(v uint64) string {
 		return strconv.FormatUint(v, 10)


### PR DESCRIPTION
Follows from the discussion: https://github.com/hashicorp/raft/issues/137

Let me know if this is too little/too much.

I would have liked to have presented the fields as a list, but this would not format as a list in the HTML output unless it was preformatted (which I didn't think it should be).