### PR TITLE
Changes configuration API to a normal future and adds live bootstrap.

### DIFF
--- a/api.go
+++ b/api.go
@@ -473,7 +473,8 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 		}
 		r.processConfigurationLogEntry(&entry)
 	}
-	r.logger.Printf("[INFO] raft: Initial configurations: %+v", r.configurations)
+	r.logger.Printf("[INFO] raft: Initial configuration (index=%d): %+v",
+		r.configurations.latestIndex, r.configurations.latest)
 
 	// Setup a heartbeat fast-path to avoid head-of-line
 	// blocking where possible. It MUST be safe for this

--- a/api.go
+++ b/api.go
@@ -857,16 +857,18 @@ func (r *Raft) Stats() map[string]string {
 	lastLogIndex, lastLogTerm := r.getLastLog()
 	lastSnapIndex, lastSnapTerm := r.getLastSnapshot()
 	s := map[string]string{
-		"state":               r.getState().String(),
-		"term":                toString(r.getCurrentTerm()),
-		"last_log_index":      toString(lastLogIndex),
-		"last_log_term":       toString(lastLogTerm),
-		"commit_index":        toString(r.getCommitIndex()),
-		"applied_index":       toString(r.getLastApplied()),
-		"fsm_pending":         toString(uint64(len(r.fsmCommitCh))),
-		"last_snapshot_index": toString(lastSnapIndex),
-		"last_snapshot_term":  toString(lastSnapTerm),
-		"protocol_version":    toString(uint64(r.protocolVersion)),
+		"state":                r.getState().String(),
+		"term":                 toString(r.getCurrentTerm()),
+		"last_log_index":       toString(lastLogIndex),
+		"last_log_term":        toString(lastLogTerm),
+		"commit_index":         toString(r.getCommitIndex()),
+		"applied_index":        toString(r.getLastApplied()),
+		"fsm_pending":          toString(uint64(len(r.fsmCommitCh))),
+		"last_snapshot_index":  toString(lastSnapIndex),
+		"last_snapshot_term":   toString(lastSnapTerm),
+		"protocol_version":     toString(uint64(r.protocolVersion)),
+		"protocol_version_min": toString(uint64(ProtocolVersionMin)),
+		"protocol_version_max": toString(uint64(ProtocolVersionMax)),
 	}
 
 	future := r.GetConfiguration()

--- a/api.go
+++ b/api.go
@@ -228,9 +228,15 @@ func RecoverCluster(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 		return err
 	}
 
-	// Sanity check the Raft peer configuration.
-	if err := checkConfiguration(configuration); err != nil {
-		return err
+	// Sanity check the Raft peer configuration. Note that it's ok to
+	// recover to an empty configuration if you want to keep the data
+	// but not allow a given server to participate any more (you'd have
+	// to recover again, or add it back into the existing quorum from
+	// another server to use this server).
+	if len(configuration.Servers) > 0 {
+		if err := checkConfiguration(configuration); err != nil {
+			return err
+		}
 	}
 
 	// Refuse to recover if there's no existing state. This would be safe to

--- a/api.go
+++ b/api.go
@@ -474,7 +474,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 		r.processConfigurationLogEntry(&entry)
 	}
 	r.logger.Printf("[INFO] raft: Initial configuration (index=%d): %+v",
-		r.configurations.latestIndex, r.configurations.latest)
+		r.configurations.latestIndex, r.configurations.latest.Servers)
 
 	// Setup a heartbeat fast-path to avoid head-of-line
 	// blocking where possible. It MUST be safe for this
@@ -876,7 +876,8 @@ func (r *Raft) Stats() map[string]string {
 		r.logger.Printf("[WARN] raft: could not get configuration for Stats: %v", err)
 	} else {
 		configuration := future.Configuration()
-		s["latest_configuration"] = fmt.Sprintf("%+v", configuration)
+		s["latest_configuration_index"] = toString(future.Index())
+		s["latest_configuration"] = fmt.Sprintf("%+v", configuration.Servers)
 
 		// This is a legacy metric that we've seen people use in the wild.
 		hasUs := false

--- a/api.go
+++ b/api.go
@@ -875,6 +875,8 @@ func (r *Raft) Stats() map[string]string {
 		"protocol_version":     toString(uint64(r.protocolVersion)),
 		"protocol_version_min": toString(uint64(ProtocolVersionMin)),
 		"protocol_version_max": toString(uint64(ProtocolVersionMax)),
+		"snapshot_version_min": toString(uint64(SnapshotVersionMin)),
+		"snapshot_version_max": toString(uint64(SnapshotVersionMax)),
 	}
 
 	future := r.GetConfiguration()

--- a/api.go
+++ b/api.go
@@ -32,14 +32,6 @@ var (
 	// ErrEnqueueTimeout is returned when a command fails due to a timeout.
 	ErrEnqueueTimeout = errors.New("timed out enqueuing operation")
 
-	// ErrKnownPeer is returned when trying to add a peer to the configuration
-	// that already exists.
-	ErrKnownPeer = errors.New("peer already known")
-
-	// ErrUnknownPeer is returned when trying to remove a peer from the
-	// configuration that doesn't exist.
-	ErrUnknownPeer = errors.New("peer is unknown")
-
 	// ErrNothingNewToSnapshot is returned when trying to create a snapshot
 	// but there's nothing new commited to the FSM since we started.
 	ErrNothingNewToSnapshot = errors.New("nothing new to snapshot")

--- a/api.go
+++ b/api.go
@@ -136,8 +136,8 @@ type Raft struct {
 	// outside of the main thread.
 	configurationsCh chan *configurationsFuture
 
-	// bootstrapCh is used to attempt an initial bootstrap safely from
-	// outside of the main thread.
+	// bootstrapCh is used to attempt an initial bootstrap from outside of
+	// the main thread.
 	bootstrapCh chan *bootstrapFuture
 
 	// List of observers and the mutex that protects them. The observers list

--- a/future.go
+++ b/future.go
@@ -39,15 +39,11 @@ type ApplyFuture interface {
 // ConfigurationFuture is used for GetConfiguration and can return the
 // latest configuration in use by Raft.
 type ConfigurationFuture interface {
-	Future
+	IndexFuture
 
 	// Configuration contains the latest configuration. This must
 	// not be called until after the Error method has returned.
 	Configuration() Configuration
-
-	// Index returns the index of the latest configuration. This
-	// must not be called until after the Error method has returned.
-	Index() uint64
 }
 
 // errorFuture is used to return a static error.

--- a/future.go
+++ b/future.go
@@ -113,6 +113,15 @@ type configurationChangeFuture struct {
 	req configurationChangeRequest
 }
 
+// bootstrapFuture is used to attempt a live bootstrap of the cluster. See the
+// Raft object's BootstrapCluster member function for more details.
+type bootstrapFuture struct {
+	deferError
+
+	// configuration is the proposed bootstrap configuration to apply.
+	configuration Configuration
+}
+
 // logFuture is used to apply a log entry and waits until
 // the log is considered committed.
 type logFuture struct {

--- a/future.go
+++ b/future.go
@@ -16,7 +16,8 @@ type Future interface {
 	Error() error
 }
 
-// IndexFuture is used for future actions that can result in a raft log entry being created.
+// IndexFuture is used for future actions that can result in a raft log entry
+// being created.
 type IndexFuture interface {
 	Future
 
@@ -25,7 +26,7 @@ type IndexFuture interface {
 	Index() uint64
 }
 
-// ApplyFuture is used for Apply() and can return the FSM response.
+// ApplyFuture is used for Apply and can return the FSM response.
 type ApplyFuture interface {
 	IndexFuture
 
@@ -33,6 +34,20 @@ type ApplyFuture interface {
 	// by the FSM.Apply method. This must not be called
 	// until after the Error method has returned.
 	Response() interface{}
+}
+
+// ConfigurationFuture is used for GetConfiguration and can return the
+// latest configuration in use by Raft.
+type ConfigurationFuture interface {
+	Future
+
+	// Configuration contains the latest configuration. This must
+	// not be called until after the Error method has returned.
+	Configuration() Configuration
+
+	// Index returns the index of the latest configuration. This
+	// must not be called until after the Error method has returned.
+	Index() uint64
 }
 
 // errorFuture is used to return a static error.
@@ -168,6 +183,16 @@ type verifyFuture struct {
 type configurationsFuture struct {
 	deferError
 	configurations configurations
+}
+
+// Configuration returns the latest configuration in use by Raft.
+func (c *configurationsFuture) Configuration() Configuration {
+	return c.configurations.latest
+}
+
+// Index returns the index of the latest configuration in use by Raft.
+func (c *configurationsFuture) Index() uint64 {
+	return c.configurations.latestIndex
 }
 
 // vote is used to respond to a verifyFuture.

--- a/raft.go
+++ b/raft.go
@@ -709,8 +709,8 @@ func (r *Raft) appendConfigurationEntry(future *configurationChangeFuture) {
 		return
 	}
 
-	r.logger.Printf("[INFO] raft: Updating configuration with %s (%v, %v) to %v",
-		future.req.command, future.req.serverID, future.req.serverAddress, configuration)
+	r.logger.Printf("[INFO] raft: Updating configuration with %s (%v, %v) to %+v",
+		future.req.command, future.req.serverID, future.req.serverAddress, configuration.Servers)
 
 	// In pre-ID compatibility mode we translate all configuration changes
 	// in to an old remove peer message, which can handle all supported

--- a/raft.go
+++ b/raft.go
@@ -91,20 +91,6 @@ func (r *Raft) setLeader(leader ServerAddress) {
 	r.leaderLock.Unlock()
 }
 
-// getConfigurations returns the full configuration information. This must not
-// be called on the main thread (which can access the information directly).
-func (r *Raft) getConfigurations() *configurationsFuture {
-	configurationsFuture := &configurationsFuture{}
-	configurationsFuture.init()
-	select {
-	case <-r.shutdownCh:
-		configurationsFuture.respond(ErrRaftShutdown)
-		return configurationsFuture
-	case r.configurationsCh <- configurationsFuture:
-		return configurationsFuture
-	}
-}
-
 // requestConfigChange is a helper for the above functions that make
 // configuration change requests. 'req' describes the change. For timeout,
 // see AddVoter.

--- a/raft_test.go
+++ b/raft_test.go
@@ -792,7 +792,7 @@ func TestRaft_RecoverCluster_EmptyConfiguration(t *testing.T) {
 
 	// Run recovery with an empty configuration.
 	if err := RecoverCluster(&r.conf, &MockFSM{}, r.logs, r.stable,
-		r.snapshots, Configuration{}); err != nil {
+		r.snapshots, r.trans, Configuration{}); err != nil {
 		c.FailNowf("[ERR] recover err: %v", err)
 	}
 


### PR DESCRIPTION
@ongardie there were two loose ends I needed to clean up. This is based off of the branch for #139 but I decided to make a separate PR for easier review.

1. It was bugging me that `GetConfiguration()` wasn't a normal `Future` since it can block, so I worked that to look like the other APIs.

2. In "bootstrap expect" mode, Consul creates a Raft object at startup and then bootstraps the cluster once the expected number of servers come online. I looked at ways to use the new `BootstrapCluster` to achieve this, but it was going to be super hard to do this correctly the way things are structured. I added a new live bootstrap capability that lets us to what we did before, but in a much safer way than the old method which just jammed some stuff in the peer store. This uses a new future/channel that the main thread consumes and makes an atomic decision to bootstrap or not based on whether there is any state present.

Added a few other small loose ends I ran into during integration.