### PR TITLE
Make benchmarks only perform Raft-permitted actions

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -66,7 +66,7 @@ func GetLog(b *testing.B, store raft.LogStore) {
 func StoreLog(b *testing.B, store raft.LogStore) {
 	// Run StoreLog a number of times
 	for n := 0; n < b.N; n++ {
-		log := &raft.Log{Index: uint64(n), Data: []byte("data")}
+		log := &raft.Log{Index: uint64(n) + 1, Data: []byte("data")}
 		if err := store.StoreLog(log); err != nil {
 			b.Fatalf("err: %s", err)
 		}

--- a/bench/bench.go
+++ b/bench/bench.go
@@ -93,15 +93,10 @@ func StoreLogs(b *testing.B, store raft.LogStore) {
 }
 
 func DeleteRange(b *testing.B, store raft.LogStore) {
-	// Create some fake data. In this case, we create 3 new log entries for each
-	// test case, and separate them by index in multiples of 10. This allows
-	// some room so that we can test deleting ranges with "extra" logs to
-	// to ensure we stop going to the database once our max index is hit.
 	var logs []*raft.Log
 	for n := 0; n < b.N; n++ {
-		offset := 10 * n
-		for i := offset; i < offset+3; i++ {
-			logs = append(logs, &raft.Log{Index: uint64(i), Data: []byte("data")})
+		for i := 0; i < 10; i++ {
+			logs = append(logs, &raft.Log{Index: uint64(n*10 + i + 1), Data: []byte("data")})
 		}
 	}
 	if err := store.StoreLogs(logs); err != nil {


### PR DESCRIPTION
See also #149.

I assume this never came to light before because both raft-boltdb and raft-mdb use a key-value store as the underlying database, so there is no inherent relation between Raft indices and anything in the database. It becomes an issue when implementing an actual log database, where database IDs correspond exactly with insertion order, so it's desirable for the Raft indices to be a simple function of database IDs.
