### PR TITLE
Added an in-mem snapshot store

### DIFF
--- a/inmem_snapshot.go
+++ b/inmem_snapshot.go
@@ -1,0 +1,72 @@
+package raft
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+)
+
+// InmemSnapshotStore implements the SnapshotStore interface and
+// retains only the most recent snapshot
+type InmemSnapshotStore struct {
+	latest *InmemSnapshotSink
+}
+
+// InmemSnapshotSink implements SnapshotSink in memory
+type InmemSnapshotSink struct {
+	meta     SnapshotMeta
+	contents []byte
+}
+
+// NewInmemSnapshotStore creates a blank new InmemSnapshotStore
+func NewInmemSnapshotStore() *InmemSnapshotStore {
+	return &InmemSnapshotStore{
+		latest: &InmemSnapshotSink{
+			contents: []byte{},
+		},
+	}
+}
+
+// Create replaces the stored snapshot with a new one using the given args
+func (m *InmemSnapshotStore) Create(index, term uint64, peers []byte) (SnapshotSink, error) {
+	name := snapshotName(term, index)
+
+	sink := m.latest
+	sink.meta.ID = name
+	sink.meta.Index = index
+	sink.meta.Term = term
+	sink.meta.Peers = peers
+	sink.contents = []byte{}
+
+	return sink, nil
+}
+
+// List returns the latest snapshot taken
+func (m *InmemSnapshotStore) List() ([]*SnapshotMeta, error) {
+	return []*SnapshotMeta{&m.latest.meta}, nil
+}
+
+// Open wraps an io.ReadCloser around the snapshot contents
+func (m *InmemSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error) {
+	return &m.latest.meta, ioutil.NopCloser(bytes.NewReader(m.latest.contents)), nil
+}
+
+// Write appends the given bytes to the snapshot contents
+func (s *InmemSnapshotSink) Write(p []byte) (n int, err error) {
+	s.contents = append(s.contents, p...)
+	return len(p), nil
+}
+
+// Close updates the Size and is otherwise a no-op
+func (s *InmemSnapshotSink) Close() error {
+	s.meta.Size = int64(len(s.contents))
+	return nil
+}
+
+func (s *InmemSnapshotSink) ID() string {
+	return s.meta.ID
+}
+
+func (s *InmemSnapshotSink) Cancel() error {
+	return nil
+}

--- a/inmem_snapshot.go
+++ b/inmem_snapshot.go
@@ -10,7 +10,8 @@ import (
 // InmemSnapshotStore implements the SnapshotStore interface and
 // retains only the most recent snapshot
 type InmemSnapshotStore struct {
-	latest *InmemSnapshotSink
+	latest      *InmemSnapshotSink
+	hasSnapshot bool
 }
 
 // InmemSnapshotSink implements SnapshotSink in memory
@@ -49,12 +50,16 @@ func (m *InmemSnapshotStore) Create(version SnapshotVersion, index, term uint64,
 		ConfigurationIndex: configurationIndex,
 	}
 	sink.contents = &bytes.Buffer{}
+	m.hasSnapshot = true
 
 	return sink, nil
 }
 
 // List returns the latest snapshot taken
 func (m *InmemSnapshotStore) List() ([]*SnapshotMeta, error) {
+	if !m.hasSnapshot {
+		return []*SnapshotMeta{}, nil
+	}
 	return []*SnapshotMeta{&m.latest.meta}, nil
 }
 

--- a/inmem_snapshot_test.go
+++ b/inmem_snapshot_test.go
@@ -1,0 +1,110 @@
+package raft
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestInmemSnapshotStoreImpl(t *testing.T) {
+	var impl interface{} = &InmemSnapshotStore{}
+	if _, ok := impl.(SnapshotStore); !ok {
+		t.Fatalf("InmemSnapshotStore not a SnapshotStore")
+	}
+}
+
+func TestInmemSnapshotSinkImpl(t *testing.T) {
+	var impl interface{} = &InmemSnapshotSink{}
+	if _, ok := impl.(SnapshotSink); !ok {
+		t.Fatalf("InmemSnapshotSink not a SnapshotSink")
+	}
+}
+
+func TestInmemSS_CreateSnapshot(t *testing.T) {
+	snap := NewInmemSnapshotStore()
+
+	// Check no snapshots
+	snaps, err := snap.List()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("should always be 1 snapshot: %v", snaps)
+	}
+
+	// Create a new sink
+	peers := []byte("all my lovely friends")
+	sink, err := snap.Create(10, 3, peers)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// The sink is not done, should not be in a list!
+	snaps, err = snap.List()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("should always be 1 snapshot: %v", snaps)
+	}
+
+	// Write to the sink
+	_, err = sink.Write([]byte("first\n"))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	_, err = sink.Write([]byte("second\n"))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Done!
+	err = sink.Close()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Should have a snapshot!
+	snaps, err = snap.List()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expect a snapshot: %v", snaps)
+	}
+
+	// Check the latest
+	latest := snaps[0]
+	if latest.Index != 10 {
+		t.Fatalf("bad snapshot: %v", *latest)
+	}
+	if latest.Term != 3 {
+		t.Fatalf("bad snapshot: %v", *latest)
+	}
+	if bytes.Compare(latest.Peers, peers) != 0 {
+		t.Fatalf("bad snapshot: %v", *latest)
+	}
+	if latest.Size != 13 {
+		t.Fatalf("bad snapshot: %d, %v", latest.Size, *latest)
+	}
+
+	// Read the snapshot
+	_, r, err := snap.Open(latest.ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Read out everything
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ensure a match
+	if bytes.Compare(buf.Bytes(), []byte("first\nsecond\n")) != 0 {
+		t.Fatalf("content mismatch")
+	}
+}

--- a/inmem_snapshot_test.go
+++ b/inmem_snapshot_test.go
@@ -29,8 +29,8 @@ func TestInmemSS_CreateSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(snaps) != 1 {
-		t.Fatalf("should always be 1 snapshot: %v", snaps)
+	if len(snaps) != 0 {
+		t.Fatalf("did not expect any snapshots: %v", snaps)
 	}
 
 	// Create a new sink


### PR DESCRIPTION
Added an in-memory snapshot store that keeps the most recent snapshot for opening, to support hashicorp/consul#2439.
