### PR TITLE
fix peers.json perms

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -118,5 +118,5 @@ func (j *JSONPeers) SetPeers(peers []string) error {
 	}
 
 	// Write out as JSON
-	return ioutil.WriteFile(j.path, buf.Bytes(), 0755)
+	return ioutil.WriteFile(j.path, buf.Bytes(), 0644)
 }


### PR DESCRIPTION
This file isn't executable, so it doesn't make a lot of sense for it to
have +x.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>