### PR TITLE
Allow streaming of snapshots without a size known in advance

### DIFF
--- a/net_transport.go
+++ b/net_transport.go
@@ -87,6 +87,11 @@ type StreamLayer interface {
 	Dial(address string, timeout time.Duration) (net.Conn, error)
 }
 
+type HalfClosableConn interface {
+	net.Conn
+	CloseWrite() error
+}
+
 type netConn struct {
 	target string
 	conn   net.Conn
@@ -331,13 +336,24 @@ func (n *NetworkTransport) InstallSnapshot(target string, args *InstallSnapshotR
 	}
 
 	// Stream the state
-	if _, err = io.Copy(conn.w, data); err != nil {
+	nBytes, err := io.Copy(conn.w, data)
+	n.logger.Printf("[INFO] Sent %d bytes of snapshot data", nBytes)
+
+	if err != nil {
 		return err
 	}
 
 	// Flush
 	if err = conn.w.Flush(); err != nil {
 		return err
+	}
+
+	if halfClosableConn, ok := conn.conn.(HalfClosableConn); ok {
+		// Close the writing half of the connection to indicate all data is sent
+		err = halfClosableConn.CloseWrite()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Decode the response, do not return conn
@@ -440,7 +456,11 @@ func (n *NetworkTransport) handleCommand(r *bufio.Reader, dec *codec.Decoder, en
 			return err
 		}
 		rpc.Command = &req
-		rpc.Reader = io.LimitReader(r, req.Size)
+		if req.Size == -1 {
+			rpc.Reader = r
+		} else {
+			rpc.Reader = io.LimitReader(r, req.Size)
+		}
 
 	default:
 		return fmt.Errorf("unknown rpc type %d", rpcType)

--- a/raft.go
+++ b/raft.go
@@ -1566,7 +1566,7 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	}
 
 	// Check that we received it all
-	if n != req.Size {
+	if req.Size != -1 && n != req.Size {
 		sink.Cancel()
 		r.logger.Printf("[ERR] raft: Failed to receive whole snapshot: %d / %d", n, req.Size)
 		rpcErr = fmt.Errorf("short read")


### PR DESCRIPTION
Right now snapshotting is heavily bound to sending a single byte stream of which the size is known in advance, such as sending a file stored on disk. However, in some cases the size is not known. For instance when gzipping the data that is being sent, or as in my case when sending a directory that is being tarred and untarred on the fly. This allows specifying a size of `-1` to indicate that the size should not be checked by raft and that other mechanisms for integrity are used.

It also changes the net_transport to support this automatically for half closable connections, such as TCP. Closing of the write half of the connection by the sender will be used to indicate the end of the snapshot and a success response can still be sent back by the receiver.