### PR TITLE
NeverLeader config: node will never switch to Candidate 

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,6 +72,12 @@ type Config struct {
 	// never be used except for testing purposes, as it can cause a split-brain.
 	StartAsLeader bool
 
+	// NeverLeader instructs this Raft node to never become the leader. This
+	// configuration may be applied on up-to quorum-1 nodes.
+	// For example, on a 3-node cluster, quorum is 2 and NeverLeader may only be applied on 1 node.
+	// On a 5-node cluster, quorum is 3 and NeverLeader may only be applied on 2 node.
+	NeverLeader bool
+
 	// NotifyCh is used to provide a channel that will be notified of leadership
 	// changes. Raft will block writing to this channel, so it should either be
 	// buffered or aggressively consumed.
@@ -131,6 +137,12 @@ func ValidateConfig(config *Config) error {
 	}
 	if config.ElectionTimeout < config.HeartbeatTimeout {
 		return fmt.Errorf("Election timeout must be equal or greater than Heartbeat Timeout")
+	}
+	if config.StartAsLeader && config.NeverLeader {
+		return fmt.Errorf("StartAsLeader and NeverLeader are mutually exclusive")
+	}
+	if config.EnableSingleNode && config.NeverLeader {
+		return fmt.Errorf("EnableSingleNode and NeverLeader are mutually exclusive")
 	}
 	return nil
 }

--- a/raft.go
+++ b/raft.go
@@ -679,6 +679,10 @@ func (r *Raft) runFollower() {
 					didWarn = true
 				}
 			} else {
+				if r.conf.NeverLeader {
+					r.logger.Printf(`[WARN] raft: Heartbeat timeout from %q reached, but NeverLeader specified. Will not enter Candidate mode`, lastLeader)
+					return
+				}
 				r.logger.Printf(`[WARN] raft: Heartbeat timeout from %q reached, starting election`, lastLeader)
 
 				metrics.IncrCounter([]string{"raft", "transition", "heartbeat_timeout"}, 1)


### PR DESCRIPTION
Storyline: https://github.com/hashicorp/raft/issues/218

This PR introduces the `NeverLeader` (`bool`) config. A node where `NeverLeader` is `true` never changes state from `Follower` to `Candidate`. Hence, it will never become a leader.

Purpose: we may have a setup where some raft nodes are mostly acting as mediator (tie breakers) but are themselves located in a remote datacenter with some latencies; we may look for the leader to be located closer to the rest of our operation.

**Danger**: you may only apply this onto (quorum-1) nodes, or else your group may be incapable of electing a leader.

- In a 3-node group, up to 1 node can be set with `NeverLeader`
  - same for 4-node group
- In a 5-node group, up to 2 nodes can be set with `NeverLeader`
  - same for 6-node group
- In a 7-node group, up to 3 nodes can be set with `NeverLeader`
  - same for 8-node group


