### PR TITLE
Put 64bit atomics at the top of structs

### DIFF
--- a/observer.go
+++ b/observer.go
@@ -29,6 +29,12 @@ type FilterFn func(o *Observation) bool
 
 // Observer describes what to do with a given observation.
 type Observer struct {
+	// numObserved and numDropped are performance counters for this observer.
+	// 64 bit types must be 64 bit aligned to use with atomic operations on
+	// 32 bit platforms, so keep them at the top of the struct.
+	numObserved uint64
+	numDropped  uint64
+
 	// channel receives observations.
 	channel chan Observation
 
@@ -42,10 +48,6 @@ type Observer struct {
 
 	// id is the ID of this observer in the Raft map.
 	id uint64
-
-	// numObserved and numDropped are performance counters for this observer.
-	numObserved uint64
-	numDropped  uint64
 }
 
 // NewObserver creates a new observer that can be registered

--- a/state.go
+++ b/state.go
@@ -42,6 +42,10 @@ func (s RaftState) String() string {
 // and provides an interface to set/get the variables in a
 // thread safe manner.
 type raftState struct {
+	// currentTerm commitIndex, lastApplied,  must be kept at the top of
+	// the struct so they're 64 bit aligned which is a requirement for
+	// atomic ops on 32 bit platforms.
+
 	// The current term, cache of StableStore
 	currentTerm uint64
 


### PR DESCRIPTION
You cannot use atomic operations on 64bit data types on 32bit
architectures unless the fields are 64bit aligned. Putting them at the
top of the struct guarantees 64bit alignment.

See https://golang.org/pkg/sync/atomic/#pkg-note-BUG

I found this when auditing Nomad for bugs like hashicorp/nomad#2963