### PR TITLE
Introduce AddressProvider interface that can be wired into the net tr…

### DIFF
--- a/api.go
+++ b/api.go
@@ -496,22 +496,6 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	r.logger.Printf("[INFO] raft: Initial configuration (index=%d): %+v",
 		r.configurations.latestIndex, r.configurations.latest.Servers)
 
-	mismatchedIP := false
-	// Fix IP address mismatches between processConfiguration log entries and this server's address
-	for index, server := range r.configurations.latest.Servers {
-		if server.ID == localID && server.Address != localAddr {
-			r.logger.Printf("[INFO] raft: Fixing IP address of server from %v to %v", server.Address, localAddr)
-			r.configurations.latest.Servers[index] = Server{server.Suffrage, server.ID, localAddr}
-			mismatchedIP = true
-			break
-		}
-	}
-
-	if mismatchedIP {
-		r.logger.Printf("[INFO] raft: Configuration after IP address fixes (index=%d): %+v",
-			r.configurations.latestIndex, r.configurations.latest.Servers)
-	}
-
 	// Setup a heartbeat fast-path to avoid head-of-line
 	// blocking where possible. It MUST be safe for this
 	// to be called concurrently with a blocking RPC.

--- a/configuration.go
+++ b/configuration.go
@@ -283,7 +283,7 @@ func encodePeers(configuration Configuration, trans Transport) []byte {
 	var encPeers [][]byte
 	for _, server := range configuration.Servers {
 		if server.Suffrage == Voter {
-			encPeers = append(encPeers, trans.EncodePeer(server.Address))
+			encPeers = append(encPeers, trans.EncodePeer(server.ID, server.Address))
 		}
 	}
 

--- a/inmem_transport.go
+++ b/inmem_transport.go
@@ -75,7 +75,7 @@ func (i *InmemTransport) LocalAddr() ServerAddress {
 
 // AppendEntriesPipeline returns an interface that can be used to pipeline
 // AppendEntries requests.
-func (i *InmemTransport) AppendEntriesPipeline(target ServerAddress) (AppendPipeline, error) {
+func (i *InmemTransport) AppendEntriesPipeline(id ServerID, target ServerAddress) (AppendPipeline, error) {
 	i.RLock()
 	peer, ok := i.peers[target]
 	i.RUnlock()
@@ -90,7 +90,7 @@ func (i *InmemTransport) AppendEntriesPipeline(target ServerAddress) (AppendPipe
 }
 
 // AppendEntries implements the Transport interface.
-func (i *InmemTransport) AppendEntries(target ServerAddress, args *AppendEntriesRequest, resp *AppendEntriesResponse) error {
+func (i *InmemTransport) AppendEntries(id ServerID, target ServerAddress, args *AppendEntriesRequest, resp *AppendEntriesResponse) error {
 	rpcResp, err := i.makeRPC(target, args, nil, i.timeout)
 	if err != nil {
 		return err
@@ -103,7 +103,7 @@ func (i *InmemTransport) AppendEntries(target ServerAddress, args *AppendEntries
 }
 
 // RequestVote implements the Transport interface.
-func (i *InmemTransport) RequestVote(target ServerAddress, args *RequestVoteRequest, resp *RequestVoteResponse) error {
+func (i *InmemTransport) RequestVote(id ServerID, target ServerAddress, args *RequestVoteRequest, resp *RequestVoteResponse) error {
 	rpcResp, err := i.makeRPC(target, args, nil, i.timeout)
 	if err != nil {
 		return err
@@ -116,7 +116,7 @@ func (i *InmemTransport) RequestVote(target ServerAddress, args *RequestVoteRequ
 }
 
 // InstallSnapshot implements the Transport interface.
-func (i *InmemTransport) InstallSnapshot(target ServerAddress, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error {
+func (i *InmemTransport) InstallSnapshot(id ServerID, target ServerAddress, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error {
 	rpcResp, err := i.makeRPC(target, args, data, 10*i.timeout)
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func (i *InmemTransport) makeRPC(target ServerAddress, args interface{}, r io.Re
 }
 
 // EncodePeer implements the Transport interface.
-func (i *InmemTransport) EncodePeer(p ServerAddress) []byte {
+func (i *InmemTransport) EncodePeer(id ServerID, p ServerAddress) []byte {
 	return []byte(p)
 }
 

--- a/net_transport.go
+++ b/net_transport.go
@@ -81,17 +81,21 @@ type NetworkTransport struct {
 }
 
 // NetworkTransportConfig encapsulates configuration for the network transport layer.
-// This includes the dialer, logger, listener and server address provider.
-// MaxPool controls how many connections we will pool. The
-// timeout is used to apply I/O deadlines. For InstallSnapshot, we multiply
-// the timeout by (SnapshotSize / TimeoutScale). The ServerAddressProvider is used to
-// override the target address when establishing a connection to invoke an RPC
 type NetworkTransportConfig struct {
+	// ServerAddressProvider is used to override the target address when establishing a connection to invoke an RPC
 	ServerAddressProvider ServerAddressProvider
-	Logger                *log.Logger
-	Stream                StreamLayer
-	MaxPool               int
-	Timeout               time.Duration
+
+	Logger *log.Logger
+
+	// Dialer
+	Stream StreamLayer
+
+	// MaxPool controls how many connections we will pool
+	MaxPool int
+
+	// Timeout is used to apply I/O deadlines. For InstallSnapshot, we multiply
+	// the timeout by (SnapshotSize / TimeoutScale).
+	Timeout time.Duration
 }
 
 type ServerAddressProvider interface {
@@ -255,8 +259,7 @@ func (n *NetworkTransport) getProviderAddressOrFallback(id ServerID, target Serv
 	if n.serverAddressProvider != nil {
 		serverAddressOverride, err := n.serverAddressProvider.ServerAddr(id)
 		if err != nil {
-			n.logger.Printf("[WARN] Unable to get address for server id %v, got error:%v", id, err)
-			n.logger.Printf("[INFO] Using fallback address %v", target)
+			n.logger.Printf("[WARN] Unable to get address for server id %v, got error:%v. Using fallback address", id, err, target)
 		} else {
 			return serverAddressOverride
 		}

--- a/net_transport.go
+++ b/net_transport.go
@@ -259,7 +259,7 @@ func (n *NetworkTransport) getProviderAddressOrFallback(id ServerID, target Serv
 	if n.serverAddressProvider != nil {
 		serverAddressOverride, err := n.serverAddressProvider.ServerAddr(id)
 		if err != nil {
-			n.logger.Printf("[WARN] Unable to get address for server id %v, got error:%v. Using fallback address", id, err, target)
+			n.logger.Printf("[WARN] Unable to get address for server id %v, using fallback address %v: %v", id, target, err)
 		} else {
 			return serverAddressOverride
 		}

--- a/net_transport_test.go
+++ b/net_transport_test.go
@@ -12,8 +12,8 @@ type testAddrProvider struct {
 	addr string
 }
 
-func (t *testAddrProvider) ServerAddr(id ServerID) ServerAddress {
-	return ServerAddress(t.addr)
+func (t *testAddrProvider) ServerAddr(id ServerID) (ServerAddress, error) {
+	return ServerAddress(t.addr), nil
 }
 
 func TestNetworkTransport_StartStop(t *testing.T) {

--- a/net_transport_test.go
+++ b/net_transport_test.go
@@ -391,7 +391,8 @@ func TestNetworkTransport_EncodeDecode(t *testing.T) {
 
 func TestNetworkTransport_EncodeDecode_AddressProvider(t *testing.T) {
 	addressOverride := "127.0.0.1:11111"
-	trans1, err := NewTCPTransportWithLoggerAndAddressProvider("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t), &testAddrProvider{addressOverride})
+	config := &NetworkTransportConfig{MaxPool: 2, Timeout: time.Second, Logger: newTestLogger(t), ServerAddressProvider: &testAddrProvider{addressOverride}}
+	trans1, err := NewTCPTransportWithConfig("127.0.0.1:0", nil, config)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -495,7 +496,8 @@ func TestNetworkTransport_PooledConn(t *testing.T) {
 
 func makeTransport(t *testing.T, useAddrProvider bool, addressOverride string) (*NetworkTransport, error) {
 	if useAddrProvider {
-		return NewTCPTransportWithLoggerAndAddressProvider("127.0.0.1:0", nil, 3, time.Second, newTestLogger(t), &testAddrProvider{addressOverride})
+		config := &NetworkTransportConfig{MaxPool: 2, Timeout: time.Second, Logger: newTestLogger(t), ServerAddressProvider: &testAddrProvider{addressOverride}}
+		return NewTCPTransportWithConfig("127.0.0.1:0", nil, config)
 	}
 	return NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
 }

--- a/net_transport_test.go
+++ b/net_transport_test.go
@@ -8,6 +8,14 @@ import (
 	"time"
 )
 
+type testAddrProvider struct {
+	addr string
+}
+
+func (t *testAddrProvider) ServerAddr(id ServerID) ServerAddress {
+	return ServerAddress(t.addr)
+}
+
 func TestNetworkTransport_StartStop(t *testing.T) {
 	trans, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
 	if err != nil {
@@ -56,7 +64,7 @@ func TestNetworkTransport_Heartbeat_FastPath(t *testing.T) {
 	defer trans2.Close()
 
 	var out AppendEntriesResponse
-	if err := trans2.AppendEntries(trans1.LocalAddr(), &args, &out); err != nil {
+	if err := trans2.AppendEntries("id1", trans1.LocalAddr(), &args, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -72,103 +80,39 @@ func TestNetworkTransport_Heartbeat_FastPath(t *testing.T) {
 }
 
 func TestNetworkTransport_AppendEntries(t *testing.T) {
-	// Transport 1 is consumer
-	trans1, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer trans1.Close()
-	rpcCh := trans1.Consumer()
 
-	// Make the RPC request
-	args := AppendEntriesRequest{
-		Term:         10,
-		Leader:       []byte("cartman"),
-		PrevLogEntry: 100,
-		PrevLogTerm:  4,
-		Entries: []*Log{
-			&Log{
-				Index: 101,
-				Term:  4,
-				Type:  LogNoop,
-			},
-		},
-		LeaderCommitIndex: 90,
-	}
-	resp := AppendEntriesResponse{
-		Term:    4,
-		LastLog: 90,
-		Success: true,
-	}
-
-	// Listen for a request
-	go func() {
-		select {
-		case rpc := <-rpcCh:
-			// Verify the command
-			req := rpc.Command.(*AppendEntriesRequest)
-			if !reflect.DeepEqual(req, &args) {
-				t.Fatalf("command mismatch: %#v %#v", *req, args)
-			}
-
-			rpc.Respond(&resp, nil)
-
-		case <-time.After(200 * time.Millisecond):
-			t.Fatalf("timeout")
+	for _, useAddrProvider := range []bool{true, false} {
+		// Transport 1 is consumer
+		trans1, err := makeTransport(t, useAddrProvider, "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("err: %v", err)
 		}
-	}()
 
-	// Transport 2 makes outbound request
-	trans2, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer trans2.Close()
+		rpcCh := trans1.Consumer()
 
-	var out AppendEntriesResponse
-	if err := trans2.AppendEntries(trans1.LocalAddr(), &args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	// Verify the response
-	if !reflect.DeepEqual(resp, out) {
-		t.Fatalf("command mismatch: %#v %#v", resp, out)
-	}
-}
-
-func TestNetworkTransport_AppendEntriesPipeline(t *testing.T) {
-	// Transport 1 is consumer
-	trans1, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer trans1.Close()
-	rpcCh := trans1.Consumer()
-
-	// Make the RPC request
-	args := AppendEntriesRequest{
-		Term:         10,
-		Leader:       []byte("cartman"),
-		PrevLogEntry: 100,
-		PrevLogTerm:  4,
-		Entries: []*Log{
-			&Log{
-				Index: 101,
-				Term:  4,
-				Type:  LogNoop,
+		// Make the RPC request
+		args := AppendEntriesRequest{
+			Term:         10,
+			Leader:       []byte("cartman"),
+			PrevLogEntry: 100,
+			PrevLogTerm:  4,
+			Entries: []*Log{
+				&Log{
+					Index: 101,
+					Term:  4,
+					Type:  LogNoop,
+				},
 			},
-		},
-		LeaderCommitIndex: 90,
-	}
-	resp := AppendEntriesResponse{
-		Term:    4,
-		LastLog: 90,
-		Success: true,
-	}
+			LeaderCommitIndex: 90,
+		}
+		resp := AppendEntriesResponse{
+			Term:    4,
+			LastLog: 90,
+			Success: true,
+		}
 
-	// Listen for a request
-	go func() {
-		for i := 0; i < 10; i++ {
+		// Listen for a request
+		go func() {
 			select {
 			case rpc := <-rpcCh:
 				// Verify the command
@@ -176,170 +120,255 @@ func TestNetworkTransport_AppendEntriesPipeline(t *testing.T) {
 				if !reflect.DeepEqual(req, &args) {
 					t.Fatalf("command mismatch: %#v %#v", *req, args)
 				}
+
 				rpc.Respond(&resp, nil)
 
 			case <-time.After(200 * time.Millisecond):
 				t.Fatalf("timeout")
 			}
-		}
-	}()
+		}()
 
-	// Transport 2 makes outbound request
-	trans2, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer trans2.Close()
-
-	pipeline, err := trans2.AppendEntriesPipeline(trans1.LocalAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer pipeline.Close()
-	for i := 0; i < 10; i++ {
-		out := new(AppendEntriesResponse)
-		if _, err := pipeline.AppendEntries(&args, out); err != nil {
+		// Transport 2 makes outbound request
+		trans2, err := makeTransport(t, useAddrProvider, string(trans1.LocalAddr()))
+		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-	}
 
-	respCh := pipeline.Consumer()
-	for i := 0; i < 10; i++ {
-		select {
-		case ready := <-respCh:
-			// Verify the response
-			if !reflect.DeepEqual(&resp, ready.Response()) {
-				t.Fatalf("command mismatch: %#v %#v", &resp, ready.Response())
-			}
-		case <-time.After(200 * time.Millisecond):
-			t.Fatalf("timeout")
+		var out AppendEntriesResponse
+		if err := trans2.AppendEntries("id1", trans1.LocalAddr(), &args, &out); err != nil {
+			t.Fatalf("err: %v", err)
 		}
+
+		// Verify the response
+		if !reflect.DeepEqual(resp, out) {
+			t.Fatalf("command mismatch: %#v %#v", resp, out)
+		}
+
+		trans2.Close()
+		trans1.Close()
+	}
+}
+
+func TestNetworkTransport_AppendEntriesPipeline(t *testing.T) {
+
+	for _, useAddrProvider := range []bool{true, false} {
+		// Transport 1 is consumer
+		trans1, err := makeTransport(t, useAddrProvider, "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		rpcCh := trans1.Consumer()
+
+		// Make the RPC request
+		args := AppendEntriesRequest{
+			Term:         10,
+			Leader:       []byte("cartman"),
+			PrevLogEntry: 100,
+			PrevLogTerm:  4,
+			Entries: []*Log{
+				&Log{
+					Index: 101,
+					Term:  4,
+					Type:  LogNoop,
+				},
+			},
+			LeaderCommitIndex: 90,
+		}
+		resp := AppendEntriesResponse{
+			Term:    4,
+			LastLog: 90,
+			Success: true,
+		}
+
+		// Listen for a request
+		go func() {
+			for i := 0; i < 10; i++ {
+				select {
+				case rpc := <-rpcCh:
+					// Verify the command
+					req := rpc.Command.(*AppendEntriesRequest)
+					if !reflect.DeepEqual(req, &args) {
+						t.Fatalf("command mismatch: %#v %#v", *req, args)
+					}
+					rpc.Respond(&resp, nil)
+
+				case <-time.After(200 * time.Millisecond):
+					t.Fatalf("timeout")
+				}
+			}
+		}()
+
+		// Transport 2 makes outbound request
+		trans2, err := makeTransport(t, useAddrProvider, string(trans1.LocalAddr()))
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		pipeline, err := trans2.AppendEntriesPipeline("id1", trans1.LocalAddr())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		for i := 0; i < 10; i++ {
+			out := new(AppendEntriesResponse)
+			if _, err := pipeline.AppendEntries(&args, out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+		}
+
+		respCh := pipeline.Consumer()
+		for i := 0; i < 10; i++ {
+			select {
+			case ready := <-respCh:
+				// Verify the response
+				if !reflect.DeepEqual(&resp, ready.Response()) {
+					t.Fatalf("command mismatch: %#v %#v", &resp, ready.Response())
+				}
+			case <-time.After(200 * time.Millisecond):
+				t.Fatalf("timeout")
+			}
+		}
+		pipeline.Close()
+		trans2.Close()
+		trans1.Close()
 	}
 }
 
 func TestNetworkTransport_RequestVote(t *testing.T) {
-	// Transport 1 is consumer
-	trans1, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer trans1.Close()
-	rpcCh := trans1.Consumer()
 
-	// Make the RPC request
-	args := RequestVoteRequest{
-		Term:         20,
-		Candidate:    []byte("butters"),
-		LastLogIndex: 100,
-		LastLogTerm:  19,
-	}
-	resp := RequestVoteResponse{
-		Term:    100,
-		Granted: false,
-	}
-
-	// Listen for a request
-	go func() {
-		select {
-		case rpc := <-rpcCh:
-			// Verify the command
-			req := rpc.Command.(*RequestVoteRequest)
-			if !reflect.DeepEqual(req, &args) {
-				t.Fatalf("command mismatch: %#v %#v", *req, args)
-			}
-
-			rpc.Respond(&resp, nil)
-
-		case <-time.After(200 * time.Millisecond):
-			t.Fatalf("timeout")
+	for _, useAddrProvider := range []bool{true, false} {
+		// Transport 1 is consumer
+		trans1, err := makeTransport(t, useAddrProvider, "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("err: %v", err)
 		}
-	}()
 
-	// Transport 2 makes outbound request
-	trans2, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer trans2.Close()
+		rpcCh := trans1.Consumer()
 
-	var out RequestVoteResponse
-	if err := trans2.RequestVote(trans1.LocalAddr(), &args, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		// Make the RPC request
+		args := RequestVoteRequest{
+			Term:         20,
+			Candidate:    []byte("butters"),
+			LastLogIndex: 100,
+			LastLogTerm:  19,
+		}
+		resp := RequestVoteResponse{
+			Term:    100,
+			Granted: false,
+		}
 
-	// Verify the response
-	if !reflect.DeepEqual(resp, out) {
-		t.Fatalf("command mismatch: %#v %#v", resp, out)
+		// Listen for a request
+		go func() {
+			select {
+			case rpc := <-rpcCh:
+				// Verify the command
+				req := rpc.Command.(*RequestVoteRequest)
+				if !reflect.DeepEqual(req, &args) {
+					t.Fatalf("command mismatch: %#v %#v", *req, args)
+				}
+
+				rpc.Respond(&resp, nil)
+
+			case <-time.After(200 * time.Millisecond):
+				t.Fatalf("timeout")
+			}
+		}()
+
+		// Transport 2 makes outbound request
+		trans2, err := makeTransport(t, useAddrProvider, string(trans1.LocalAddr()))
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		var out RequestVoteResponse
+		if err := trans2.RequestVote("id1", trans1.LocalAddr(), &args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Verify the response
+		if !reflect.DeepEqual(resp, out) {
+			t.Fatalf("command mismatch: %#v %#v", resp, out)
+		}
+
+		trans2.Close()
+		trans1.Close()
+
 	}
 }
 
 func TestNetworkTransport_InstallSnapshot(t *testing.T) {
-	// Transport 1 is consumer
-	trans1, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer trans1.Close()
-	rpcCh := trans1.Consumer()
 
-	// Make the RPC request
-	args := InstallSnapshotRequest{
-		Term:         10,
-		Leader:       []byte("kyle"),
-		LastLogIndex: 100,
-		LastLogTerm:  9,
-		Peers:        []byte("blah blah"),
-		Size:         10,
-	}
-	resp := InstallSnapshotResponse{
-		Term:    10,
-		Success: true,
-	}
-
-	// Listen for a request
-	go func() {
-		select {
-		case rpc := <-rpcCh:
-			// Verify the command
-			req := rpc.Command.(*InstallSnapshotRequest)
-			if !reflect.DeepEqual(req, &args) {
-				t.Fatalf("command mismatch: %#v %#v", *req, args)
-			}
-
-			// Try to read the bytes
-			buf := make([]byte, 10)
-			rpc.Reader.Read(buf)
-
-			// Compare
-			if bytes.Compare(buf, []byte("0123456789")) != 0 {
-				t.Fatalf("bad buf %v", buf)
-			}
-
-			rpc.Respond(&resp, nil)
-
-		case <-time.After(200 * time.Millisecond):
-			t.Fatalf("timeout")
+	for _, useAddrProvider := range []bool{true, false} {
+		// Transport 1 is consumer
+		trans1, err := makeTransport(t, useAddrProvider, "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("err: %v", err)
 		}
-	}()
 
-	// Transport 2 makes outbound request
-	trans2, err := NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer trans2.Close()
+		rpcCh := trans1.Consumer()
 
-	// Create a buffer
-	buf := bytes.NewBuffer([]byte("0123456789"))
+		// Make the RPC request
+		args := InstallSnapshotRequest{
+			Term:         10,
+			Leader:       []byte("kyle"),
+			LastLogIndex: 100,
+			LastLogTerm:  9,
+			Peers:        []byte("blah blah"),
+			Size:         10,
+		}
+		resp := InstallSnapshotResponse{
+			Term:    10,
+			Success: true,
+		}
 
-	var out InstallSnapshotResponse
-	if err := trans2.InstallSnapshot(trans1.LocalAddr(), &args, &out, buf); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		// Listen for a request
+		go func() {
+			select {
+			case rpc := <-rpcCh:
+				// Verify the command
+				req := rpc.Command.(*InstallSnapshotRequest)
+				if !reflect.DeepEqual(req, &args) {
+					t.Fatalf("command mismatch: %#v %#v", *req, args)
+				}
 
-	// Verify the response
-	if !reflect.DeepEqual(resp, out) {
-		t.Fatalf("command mismatch: %#v %#v", resp, out)
+				// Try to read the bytes
+				buf := make([]byte, 10)
+				rpc.Reader.Read(buf)
+
+				// Compare
+				if bytes.Compare(buf, []byte("0123456789")) != 0 {
+					t.Fatalf("bad buf %v", buf)
+				}
+
+				rpc.Respond(&resp, nil)
+
+			case <-time.After(200 * time.Millisecond):
+				t.Fatalf("timeout")
+			}
+		}()
+
+		// Transport 2 makes outbound request
+		trans2, err := makeTransport(t, useAddrProvider, string(trans1.LocalAddr()))
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Create a buffer
+		buf := bytes.NewBuffer([]byte("0123456789"))
+
+		var out InstallSnapshotResponse
+		if err := trans2.InstallSnapshot("id1", trans1.LocalAddr(), &args, &out, buf); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Verify the response
+		if !reflect.DeepEqual(resp, out) {
+			t.Fatalf("command mismatch: %#v %#v", resp, out)
+		}
+
+		trans2.Close()
+		trans1.Close()
 	}
 }
 
@@ -352,11 +381,28 @@ func TestNetworkTransport_EncodeDecode(t *testing.T) {
 	defer trans1.Close()
 
 	local := trans1.LocalAddr()
-	enc := trans1.EncodePeer(local)
+	enc := trans1.EncodePeer("id1", local)
 	dec := trans1.DecodePeer(enc)
 
 	if dec != local {
 		t.Fatalf("enc/dec fail: %v %v", dec, local)
+	}
+}
+
+func TestNetworkTransport_EncodeDecode_AddressProvider(t *testing.T) {
+	addressOverride := "127.0.0.1:11111"
+	trans1, err := NewTCPTransportWithLoggerAndAddressProvider("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t), &testAddrProvider{addressOverride})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer trans1.Close()
+
+	local := trans1.LocalAddr()
+	enc := trans1.EncodePeer("id1", local)
+	dec := trans1.DecodePeer(enc)
+
+	if dec != ServerAddress(addressOverride) {
+		t.Fatalf("enc/dec fail: %v %v", dec, addressOverride)
 	}
 }
 
@@ -422,7 +468,7 @@ func TestNetworkTransport_PooledConn(t *testing.T) {
 	appendFunc := func() {
 		defer wg.Done()
 		var out AppendEntriesResponse
-		if err := trans2.AppendEntries(trans1.LocalAddr(), &args, &out); err != nil {
+		if err := trans2.AppendEntries("id1", trans1.LocalAddr(), &args, &out); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -445,4 +491,11 @@ func TestNetworkTransport_PooledConn(t *testing.T) {
 	if len(trans2.connPool[addr]) != 3 {
 		t.Fatalf("Expected 2 pooled conns!")
 	}
+}
+
+func makeTransport(t *testing.T, useAddrProvider bool, addressOverride string) (*NetworkTransport, error) {
+	if useAddrProvider {
+		return NewTCPTransportWithLoggerAndAddressProvider("127.0.0.1:0", nil, 3, time.Second, newTestLogger(t), &testAddrProvider{addressOverride})
+	}
+	return NewTCPTransportWithLogger("127.0.0.1:0", nil, 2, time.Second, newTestLogger(t))
 }

--- a/net_transport_test.go
+++ b/net_transport_test.go
@@ -87,7 +87,7 @@ func TestNetworkTransport_AppendEntries(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-
+		defer trans1.Close()
 		rpcCh := trans1.Consumer()
 
 		// Make the RPC request
@@ -133,6 +133,7 @@ func TestNetworkTransport_AppendEntries(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		defer trans2.Close()
 
 		var out AppendEntriesResponse
 		if err := trans2.AppendEntries("id1", trans1.LocalAddr(), &args, &out); err != nil {
@@ -144,8 +145,6 @@ func TestNetworkTransport_AppendEntries(t *testing.T) {
 			t.Fatalf("command mismatch: %#v %#v", resp, out)
 		}
 
-		trans2.Close()
-		trans1.Close()
 	}
 }
 
@@ -157,7 +156,7 @@ func TestNetworkTransport_AppendEntriesPipeline(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-
+		defer trans1.Close()
 		rpcCh := trans1.Consumer()
 
 		// Make the RPC request
@@ -204,7 +203,7 @@ func TestNetworkTransport_AppendEntriesPipeline(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-
+		defer trans2.Close()
 		pipeline, err := trans2.AppendEntriesPipeline("id1", trans1.LocalAddr())
 		if err != nil {
 			t.Fatalf("err: %v", err)
@@ -230,8 +229,7 @@ func TestNetworkTransport_AppendEntriesPipeline(t *testing.T) {
 			}
 		}
 		pipeline.Close()
-		trans2.Close()
-		trans1.Close()
+
 	}
 }
 
@@ -243,7 +241,7 @@ func TestNetworkTransport_RequestVote(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-
+		defer trans1.Close()
 		rpcCh := trans1.Consumer()
 
 		// Make the RPC request
@@ -280,7 +278,7 @@ func TestNetworkTransport_RequestVote(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-
+		defer trans2.Close()
 		var out RequestVoteResponse
 		if err := trans2.RequestVote("id1", trans1.LocalAddr(), &args, &out); err != nil {
 			t.Fatalf("err: %v", err)
@@ -290,9 +288,6 @@ func TestNetworkTransport_RequestVote(t *testing.T) {
 		if !reflect.DeepEqual(resp, out) {
 			t.Fatalf("command mismatch: %#v %#v", resp, out)
 		}
-
-		trans2.Close()
-		trans1.Close()
 
 	}
 }
@@ -305,7 +300,7 @@ func TestNetworkTransport_InstallSnapshot(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-
+		defer trans1.Close()
 		rpcCh := trans1.Consumer()
 
 		// Make the RPC request
@@ -353,7 +348,7 @@ func TestNetworkTransport_InstallSnapshot(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-
+		defer trans2.Close()
 		// Create a buffer
 		buf := bytes.NewBuffer([]byte("0123456789"))
 
@@ -367,8 +362,6 @@ func TestNetworkTransport_InstallSnapshot(t *testing.T) {
 			t.Fatalf("command mismatch: %#v %#v", resp, out)
 		}
 
-		trans2.Close()
-		trans1.Close()
 	}
 }
 

--- a/raft.go
+++ b/raft.go
@@ -1379,7 +1379,7 @@ func (r *Raft) electSelf() <-chan *voteResult {
 	req := &RequestVoteRequest{
 		RPCHeader:    r.getRPCHeader(),
 		Term:         r.getCurrentTerm(),
-		Candidate:    r.trans.EncodePeer(r.localAddr),
+		Candidate:    r.trans.EncodePeer(r.localID, r.localAddr),
 		LastLogIndex: lastIdx,
 		LastLogTerm:  lastTerm,
 	}
@@ -1389,7 +1389,7 @@ func (r *Raft) electSelf() <-chan *voteResult {
 		r.goFunc(func() {
 			defer metrics.MeasureSince([]string{"raft", "candidate", "electSelf"}, time.Now())
 			resp := &voteResult{voterID: peer.ID}
-			err := r.trans.RequestVote(peer.Address, req, &resp.RequestVoteResponse)
+			err := r.trans.RequestVote(peer.ID, peer.Address, req, &resp.RequestVoteResponse)
 			if err != nil {
 				r.logger.Printf("[ERR] raft: Failed to make RequestVote RPC to %v: %v", peer, err)
 				resp.Term = req.Term

--- a/tcp_transport.go
+++ b/tcp_transport.go
@@ -47,6 +47,35 @@ func NewTCPTransportWithLogger(
 	})
 }
 
+// NewTCPTransportWithLogger returns a NetworkTransport that is built on top of
+// a TCP streaming transport layer, using a default logger and the address provider
+func NewTCPTransportWithAddressProvider(
+	bindAddr string,
+	advertise net.Addr,
+	maxPool int,
+	timeout time.Duration,
+	addrProvider ServerAddressProvider,
+) (*NetworkTransport, error) {
+	return newTCPTransport(bindAddr, advertise, maxPool, timeout, func(stream StreamLayer) *NetworkTransport {
+		return NewNetworkTransportWithServerAddressProvider(stream, maxPool, timeout, addrProvider)
+	})
+}
+
+// NewTCPTransportWithLogger returns a NetworkTransport that is built on top of
+// a TCP streaming transport layer, with the supplied Logger and address provider
+func NewTCPTransportWithLoggerAndAddressProvider(
+	bindAddr string,
+	advertise net.Addr,
+	maxPool int,
+	timeout time.Duration,
+	logger *log.Logger,
+	addrProvider ServerAddressProvider,
+) (*NetworkTransport, error) {
+	return newTCPTransport(bindAddr, advertise, maxPool, timeout, func(stream StreamLayer) *NetworkTransport {
+		return NewNetworkTransportWithLoggerAndServerAddressProvider(stream, maxPool, timeout, logger, addrProvider)
+	})
+}
+
 func newTCPTransport(bindAddr string,
 	advertise net.Addr,
 	maxPool int,

--- a/tcp_transport.go
+++ b/tcp_transport.go
@@ -28,7 +28,7 @@ func NewTCPTransport(
 	timeout time.Duration,
 	logOutput io.Writer,
 ) (*NetworkTransport, error) {
-	return newTCPTransport(bindAddr, advertise, maxPool, timeout, func(stream StreamLayer) *NetworkTransport {
+	return newTCPTransport(bindAddr, advertise, func(stream StreamLayer) *NetworkTransport {
 		return NewNetworkTransport(stream, maxPool, timeout, logOutput)
 	})
 }
@@ -42,44 +42,26 @@ func NewTCPTransportWithLogger(
 	timeout time.Duration,
 	logger *log.Logger,
 ) (*NetworkTransport, error) {
-	return newTCPTransport(bindAddr, advertise, maxPool, timeout, func(stream StreamLayer) *NetworkTransport {
+	return newTCPTransport(bindAddr, advertise, func(stream StreamLayer) *NetworkTransport {
 		return NewNetworkTransportWithLogger(stream, maxPool, timeout, logger)
 	})
 }
 
 // NewTCPTransportWithLogger returns a NetworkTransport that is built on top of
 // a TCP streaming transport layer, using a default logger and the address provider
-func NewTCPTransportWithAddressProvider(
+func NewTCPTransportWithConfig(
 	bindAddr string,
 	advertise net.Addr,
-	maxPool int,
-	timeout time.Duration,
-	addrProvider ServerAddressProvider,
+	config *NetworkTransportConfig,
 ) (*NetworkTransport, error) {
-	return newTCPTransport(bindAddr, advertise, maxPool, timeout, func(stream StreamLayer) *NetworkTransport {
-		return NewNetworkTransportWithServerAddressProvider(stream, maxPool, timeout, addrProvider)
-	})
-}
-
-// NewTCPTransportWithLogger returns a NetworkTransport that is built on top of
-// a TCP streaming transport layer, with the supplied Logger and address provider
-func NewTCPTransportWithLoggerAndAddressProvider(
-	bindAddr string,
-	advertise net.Addr,
-	maxPool int,
-	timeout time.Duration,
-	logger *log.Logger,
-	addrProvider ServerAddressProvider,
-) (*NetworkTransport, error) {
-	return newTCPTransport(bindAddr, advertise, maxPool, timeout, func(stream StreamLayer) *NetworkTransport {
-		return NewNetworkTransportWithLoggerAndServerAddressProvider(stream, maxPool, timeout, logger, addrProvider)
+	return newTCPTransport(bindAddr, advertise, func(stream StreamLayer) *NetworkTransport {
+		config.Stream = stream
+		return NewNetworkTransportWithConfig(config)
 	})
 }
 
 func newTCPTransport(bindAddr string,
 	advertise net.Addr,
-	maxPool int,
-	timeout time.Duration,
 	transportCreator func(stream StreamLayer) *NetworkTransport) (*NetworkTransport, error) {
 	// Try to bind
 	list, err := net.Listen("tcp", bindAddr)

--- a/transport.go
+++ b/transport.go
@@ -35,20 +35,20 @@ type Transport interface {
 
 	// AppendEntriesPipeline returns an interface that can be used to pipeline
 	// AppendEntries requests.
-	AppendEntriesPipeline(target ServerAddress) (AppendPipeline, error)
+	AppendEntriesPipeline(id ServerID, target ServerAddress) (AppendPipeline, error)
 
 	// AppendEntries sends the appropriate RPC to the target node.
-	AppendEntries(target ServerAddress, args *AppendEntriesRequest, resp *AppendEntriesResponse) error
+	AppendEntries(id ServerID, target ServerAddress, args *AppendEntriesRequest, resp *AppendEntriesResponse) error
 
 	// RequestVote sends the appropriate RPC to the target node.
-	RequestVote(target ServerAddress, args *RequestVoteRequest, resp *RequestVoteResponse) error
+	RequestVote(id ServerID, target ServerAddress, args *RequestVoteRequest, resp *RequestVoteResponse) error
 
 	// InstallSnapshot is used to push a snapshot down to a follower. The data is read from
 	// the ReadCloser and streamed to the client.
-	InstallSnapshot(target ServerAddress, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error
+	InstallSnapshot(id ServerID, target ServerAddress, args *InstallSnapshotRequest, resp *InstallSnapshotResponse, data io.Reader) error
 
 	// EncodePeer is used to serialize a peer's address.
-	EncodePeer(ServerAddress) []byte
+	EncodePeer(id ServerID, addr ServerAddress) []byte
 
 	// DecodePeer is used to deserialize a peer's address.
 	DecodePeer([]byte) ServerAddress

--- a/transport_test.go
+++ b/transport_test.go
@@ -84,7 +84,7 @@ func TestTransport_AppendEntries(t *testing.T) {
 		trans2.Connect(addr1, trans1)
 
 		var out AppendEntriesResponse
-		if err := trans2.AppendEntries(trans1.LocalAddr(), &args, &out); err != nil {
+		if err := trans2.AppendEntries("id1", trans1.LocalAddr(), &args, &out); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -147,7 +147,7 @@ func TestTransport_AppendEntriesPipeline(t *testing.T) {
 		trans1.Connect(addr2, trans2)
 		trans2.Connect(addr1, trans1)
 
-		pipeline, err := trans2.AppendEntriesPipeline(trans1.LocalAddr())
+		pipeline, err := trans2.AppendEntriesPipeline("id1", trans1.LocalAddr())
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -217,7 +217,7 @@ func TestTransport_RequestVote(t *testing.T) {
 		trans2.Connect(addr1, trans1)
 
 		var out RequestVoteResponse
-		if err := trans2.RequestVote(trans1.LocalAddr(), &args, &out); err != nil {
+		if err := trans2.RequestVote("id1", trans1.LocalAddr(), &args, &out); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -285,7 +285,7 @@ func TestTransport_InstallSnapshot(t *testing.T) {
 		buf := bytes.NewBuffer([]byte("0123456789"))
 
 		var out InstallSnapshotResponse
-		if err := trans2.InstallSnapshot(trans1.LocalAddr(), &args, &out, buf); err != nil {
+		if err := trans2.InstallSnapshot("id1", trans1.LocalAddr(), &args, &out, buf); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -302,7 +302,7 @@ func TestTransport_EncodeDecode(t *testing.T) {
 		defer trans1.Close()
 
 		local := trans1.LocalAddr()
-		enc := trans1.EncodePeer(local)
+		enc := trans1.EncodePeer("aaaa", local)
 		dec := trans1.DecodePeer(enc)
 
 		if dec != local {


### PR DESCRIPTION
…ansport layer. This allows overriding ip addresses of nodes when establishing connections to peers. All methods in transport interface now take a server ID to pass to the AddressProvider.