### PR TITLE
Add support for snapshots that don't have a known size

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -129,6 +129,9 @@ type InstallSnapshotRequest struct {
 
 	// Size of the snapshot
 	Size int64
+	// EstimatedSize is used to calculate the timeout on the transfer if size
+	// is unknown, i.e. -1
+	EstimatedSize int64
 }
 
 // See WithRPCHeader.

--- a/net_transport.go
+++ b/net_transport.go
@@ -111,6 +111,11 @@ type StreamLayer interface {
 	Dial(address ServerAddress, timeout time.Duration) (net.Conn, error)
 }
 
+type HalfClosableConn interface {
+	net.Conn
+	CloseWrite() error
+}
+
 type netConn struct {
 	target ServerAddress
 	conn   net.Conn
@@ -371,7 +376,12 @@ func (n *NetworkTransport) InstallSnapshot(id ServerID, target ServerAddress, ar
 
 	// Set a deadline, scaled by request size
 	if n.timeout > 0 {
-		timeout := n.timeout * time.Duration(args.Size/int64(n.TimeoutScale))
+		transferSize := args.EstimatedSize
+		if args.Size > 0 {
+			transferSize = args.Size
+		}
+
+		timeout := n.timeout * time.Duration(transferSize/int64(n.TimeoutScale))
 		if timeout < n.timeout {
 			timeout = n.timeout
 		}
@@ -384,13 +394,24 @@ func (n *NetworkTransport) InstallSnapshot(id ServerID, target ServerAddress, ar
 	}
 
 	// Stream the state
-	if _, err = io.Copy(conn.w, data); err != nil {
+	nBytes, err := io.Copy(conn.w, data)
+	n.logger.Printf("[INFO] Sent %d bytes of snapshot data", nBytes)
+
+	if err != nil {
 		return err
 	}
 
 	// Flush
 	if err = conn.w.Flush(); err != nil {
 		return err
+	}
+
+	if halfClosableConn, ok := conn.conn.(HalfClosableConn); ok {
+		// Close the writing half of the connection to indicate all data is sent
+		err = halfClosableConn.CloseWrite()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Decode the response, do not return conn
@@ -494,7 +515,11 @@ func (n *NetworkTransport) handleCommand(r *bufio.Reader, dec *codec.Decoder, en
 			return err
 		}
 		rpc.Command = &req
-		rpc.Reader = io.LimitReader(r, req.Size)
+		if req.Size == -1 {
+			rpc.Reader = r
+		} else {
+			rpc.Reader = io.LimitReader(r, req.Size)
+		}
 
 	default:
 		return fmt.Errorf("unknown rpc type %d", rpcType)

--- a/raft.go
+++ b/raft.go
@@ -754,7 +754,7 @@ func (r *Raft) restoreUserSnapshot(meta *SnapshotMeta, reader io.Reader) error {
 		sink.Cancel()
 		return fmt.Errorf("failed to write snapshot: %v", err)
 	}
-	if n != meta.Size {
+	if n != meta.Size && meta.Size != -1 {
 		sink.Cancel()
 		return fmt.Errorf("failed to write snapshot, size didn't match (%d != %d)", n, meta.Size)
 	}
@@ -1296,7 +1296,7 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	}
 
 	// Check that we received it all
-	if n != req.Size {
+	if req.Size != -1 && n != req.Size {
 		sink.Cancel()
 		r.logger.Printf("[ERR] raft: Failed to receive whole snapshot: %d / %d", n, req.Size)
 		rpcErr = fmt.Errorf("short read")

--- a/replication.go
+++ b/replication.go
@@ -283,6 +283,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 		LastLogTerm:        meta.Term,
 		Peers:              meta.Peers,
 		Size:               meta.Size,
+		EstimatedSize:      meta.EstimatedSize,
 		Configuration:      encodeConfiguration(meta.Configuration),
 		ConfigurationIndex: meta.ConfigurationIndex,
 	}

--- a/snapshot.go
+++ b/snapshot.go
@@ -33,6 +33,9 @@ type SnapshotMeta struct {
 
 	// Size is the size of the snapshot in bytes.
 	Size int64
+	// EstimatedSize is the estimated size of the snapshot in bytes if the
+	// precise size is not available.
+	EstimatedSize int64
 }
 
 // SnapshotStore interface is used to allow for flexible implementations


### PR DESCRIPTION
Follow up on #210 that can be merged into `library-v2-stage-one`. 

Right now snapshotting is heavily bound to sending a single byte stream of
which the size is known in advance, such as sending a file stored on disk.
However, in some cases the size is not known. For instance when gzipping the
data that is being sent, or as in my case when sending a directory that is
being tarred and untarred on the fly. This allows specifying a `Size` of `-1` to
indicate that the size should not be checked by raft and that other mechanisms
for integrity are used.

It also changes the `NetworkTransport` to support this automatically for half
closable connections, such as TCP. Closing of the write half of the connection
by the sender will be used to indicate the end of the snapshot and a success
response can still be sent back by the receiver.

It also adds a `EstimatedSize` field to `SnapshotMeta` and
`InstallSnapshotRequest`. This is used when determining the timeout for the
transfer.

This closes #210, as that contains some problems fixed here.