### PR TITLE
Make shutdown graceful and improve and speed up election

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: go
 
 go:
-    - 1.6
+    # Disabled until https://github.com/armon/go-metrics/issues/59 is fixed
+    # - 1.6
+    - 1.8
+    - 1.9
     - tip
 
 install: make deps

--- a/api.go
+++ b/api.go
@@ -156,6 +156,11 @@ type Raft struct {
 	// is indexed by an artificial ID which is used for deregistration.
 	observersLock sync.RWMutex
 	observers     map[uint64]*Observer
+
+	// startedAt is used to store the time at which raft started running.
+	startedAt time.Time
+	// receivedRequestVote stores if the node has received a request to vote.
+	receivedRequestVote bool
 }
 
 // BootstrapCluster initializes a server's storage with the given cluster

--- a/config.go
+++ b/config.go
@@ -146,6 +146,8 @@ type Config struct {
 
 	// MaximumBackoff specifies the maximum time between heartbeats from the
 	// leader to a follower when the follower is considered down by the leader.
+	// Nodes that just started will wait twice this time before starting an
+	// election to give the current leader time to contact them.
 	MaximumBackoff time.Duration
 
 	// MaxAppendEntries controls the maximum number of append entries

--- a/config.go
+++ b/config.go
@@ -130,6 +130,11 @@ type Config struct {
 	// a leader before we attempt an election.
 	HeartbeatTimeout time.Duration
 
+	// HeartbeatInterval specifies the interval at which heartbeats should be
+	// sent to a follower. If this is set to 0 the interval will default to
+	// HeartbeatTimeout / 10.
+	HeartbeatInterval time.Duration
+
 	// ElectionTimeout specifies the time in candidate state without
 	// a leader before we attempt an election.
 	ElectionTimeout time.Duration
@@ -253,6 +258,9 @@ func ValidateConfig(config *Config) error {
 	}
 	if config.ElectionTimeout < config.HeartbeatTimeout {
 		return fmt.Errorf("Election timeout must be equal or greater than Heartbeat Timeout")
+	}
+	if config.HeartbeatTimeout < config.HeartbeatInterval*2 {
+		return fmt.Errorf("Heartbeat timeout should be at least twice as large as the heartbeat interval")
 	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -144,6 +144,10 @@ type Config struct {
 	// staggering, may be delayed as much as 2x this value.
 	CommitTimeout time.Duration
 
+	// MaximumBackoff specifies the maximum time between heartbeats from the
+	// leader to a follower when the follower is considered down by the leader.
+	MaximumBackoff time.Duration
+
 	// MaxAppendEntries controls the maximum number of append entries
 	// to send at once. We want to strike a balance between efficiency
 	// and avoiding waste if the follower is going to reject because of
@@ -206,6 +210,7 @@ func DefaultConfig() *Config {
 		ProtocolVersion:    ProtocolVersionMax,
 		HeartbeatTimeout:   1000 * time.Millisecond,
 		ElectionTimeout:    1000 * time.Millisecond,
+		MaximumBackoff:     5 * time.Second,
 		CommitTimeout:      50 * time.Millisecond,
 		MaxAppendEntries:   64,
 		ShutdownOnRemove:   true,

--- a/config.go
+++ b/config.go
@@ -256,9 +256,6 @@ func ValidateConfig(config *Config) error {
 	if config.LeaderLeaseTimeout > config.HeartbeatTimeout {
 		return fmt.Errorf("Leader lease timeout cannot be larger than heartbeat timeout")
 	}
-	if config.ElectionTimeout < config.HeartbeatTimeout {
-		return fmt.Errorf("Election timeout must be equal or greater than Heartbeat Timeout")
-	}
 	if config.HeartbeatTimeout < config.HeartbeatInterval*2 {
 		return fmt.Errorf("Heartbeat timeout should be at least twice as large as the heartbeat interval")
 	}

--- a/raft.go
+++ b/raft.go
@@ -1120,6 +1120,9 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 	// leader
 	if r.Leader() == "" {
 		r.logger.Printf("[INFO] raft: Leader has shut down")
+		// Increment current term, so queued appendEntries from leader that is
+		// shutting down are ignored.
+		r.setCurrentTerm(a.Term + 1)
 		return
 	}
 

--- a/raft.go
+++ b/raft.go
@@ -1158,14 +1158,6 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 		resp.Peers = encodePeers(r.configurations.latest, r.trans)
 	}
 
-	// Check if we have an existing leader [who's not the candidate]
-	candidate := r.trans.DecodePeer(req.Candidate)
-	if leader := r.Leader(); leader != "" && leader != candidate {
-		r.logger.Printf("[WARN] raft: Rejecting vote request from %v since we have a leader: %v",
-			candidate, leader)
-		return
-	}
-
 	// Ignore an older term
 	if req.Term < r.getCurrentTerm() {
 		return
@@ -1190,6 +1182,8 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 		r.logger.Printf("[ERR] raft: Failed to get last vote candidate: %v", err)
 		return
 	}
+
+	candidate := r.trans.DecodePeer(req.Candidate)
 
 	// Check if we've voted in this election before
 	if lastVoteTerm == req.Term && lastVoteCandBytes != nil {

--- a/raft.go
+++ b/raft.go
@@ -1110,8 +1110,12 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 		r.setState(Follower)
 	}
 
-	// Save the current leader
-	r.setLeader(ServerAddress(r.trans.DecodePeer(a.Leader)))
+	leader := r.trans.DecodePeer(a.Leader)
+	if r.Leader() != leader {
+		// Save the current leader
+		r.logger.Printf("[INFO] raft: Changing leader from %q to %q", r.Leader(), leader)
+		r.setLeader(leader)
+	}
 	// If leader got unset by appendEntries it was a shutdown signal from the
 	// leader
 	if r.Leader() == "" {

--- a/raft.go
+++ b/raft.go
@@ -703,9 +703,6 @@ func (r *Raft) leaderLoop() {
 			lease = time.After(checkInterval)
 
 		case <-r.shutdownCh:
-			for _, replState := range r.leaderState.replState {
-				r.sendShutdown(replState)
-			}
 			return
 		}
 	}

--- a/raft.go
+++ b/raft.go
@@ -1267,6 +1267,29 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 		return
 	}
 
+	candidate := r.trans.DecodePeer(req.Candidate)
+
+	var candidateServer *Server
+	for _, server := range r.configurations.latest.Servers {
+		if server.Address == candidate {
+			candidateServer = &server
+			break
+		}
+	}
+
+	// If the candidate is not part of the latest configuration ignore its
+	// voting request
+	if candidateServer == nil {
+		r.logger.Printf("[WARN] raft: Rejecting vote request from %v, since it'not part of the configuration", candidate)
+		return
+	}
+
+	// If the candidate is not a voter, ignore its voting request
+	if candidateServer.Suffrage != Voter {
+		r.logger.Printf("[WARN] raft: Rejecting vote request from %v, since it's a non voting server", candidate)
+		return
+	}
+
 	// Increase the term if we see a newer one
 	if req.Term > r.getCurrentTerm() {
 		// Ensure transition to follower
@@ -1286,8 +1309,6 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 		r.logger.Printf("[ERR] raft: Failed to get last vote candidate: %v", err)
 		return
 	}
-
-	candidate := r.trans.DecodePeer(req.Candidate)
 
 	// Check if we've voted in this election before
 	if lastVoteTerm == req.Term && lastVoteCandBytes != nil {

--- a/raft.go
+++ b/raft.go
@@ -1109,7 +1109,9 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 	}
 
 	// Ensure transition to follower
-	r.setState(Follower)
+	if r.getState() != Follower {
+		r.setState(Follower)
+	}
 
 	// Save the current leader
 	r.setLeader(ServerAddress(r.trans.DecodePeer(a.Leader)))

--- a/raft_test.go
+++ b/raft_test.go
@@ -75,6 +75,7 @@ func inmemConfig(t *testing.T) *Config {
 	conf.ElectionTimeout = 50 * time.Millisecond
 	conf.LeaderLeaseTimeout = 50 * time.Millisecond
 	conf.CommitTimeout = 5 * time.Millisecond
+	conf.MaximumBackoff = 0
 	conf.Logger = newTestLogger(t)
 	return conf
 }

--- a/replication.go
+++ b/replication.go
@@ -346,6 +346,9 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 		case <-stopCh:
 			return
 		}
+		if r.getShuttingDown() {
+			return
+		}
 
 		start := time.Now()
 		if err := r.trans.AppendEntries(s.peer.ID, s.peer.Address, &req, &resp); err != nil {

--- a/replication.go
+++ b/replication.go
@@ -381,6 +381,7 @@ func (r *Raft) sendShutdown(s *followerReplication) {
 	if err := r.trans.AppendEntries(s.peer.ID, s.peer.Address, &req, &resp); err != nil {
 		r.logger.Printf("[ERR] raft: Failed to notify to %v that this node is shutting down: %v", s.peer.Address, err)
 	} else {
+		r.logger.Printf("[INFO] raft: Successfully notified %v that this node is shutting down", s.peer.Address)
 		s.setLastContact()
 		metrics.MeasureSince([]string{"raft", "replication", "shutdown", string(s.peer.ID)}, start)
 	}

--- a/replication.go
+++ b/replication.go
@@ -337,9 +337,13 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 	var resp AppendEntriesResponse
 	for {
 		// Wait for the next heartbeat interval or forced notify
+		interval := r.conf.HeartbeatInterval
+		if interval == 0 {
+			interval = r.conf.HeartbeatInterval / 10
+		}
 		select {
 		case <-s.notifyCh:
-		case <-randomTimeout(r.conf.HeartbeatTimeout / 10):
+		case <-time.After(interval):
 		case <-stopCh:
 			return
 		}

--- a/replication.go
+++ b/replication.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	maxFailureScale = 12
-	failureWait     = 10 * time.Millisecond
+	failureWait = 10 * time.Millisecond
 )
 
 var (
@@ -169,7 +168,7 @@ START:
 	// Prevent an excessive retry rate on errors
 	if s.failures > 0 {
 		select {
-		case <-time.After(backoff(failureWait, s.failures, maxFailureScale)):
+		case <-time.After(backoff(failureWait, r.conf.MaximumBackoff, s.failures)):
 		case <-r.shutdownCh:
 		}
 	}
@@ -353,7 +352,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			r.logger.Printf("[ERR] raft: Failed to heartbeat to %v: %v", s.peer.Address, err)
 			failures++
 			select {
-			case <-time.After(backoff(failureWait, failures, maxFailureScale)):
+			case <-time.After(backoff(failureWait, r.conf.MaximumBackoff, failures)):
 			case <-stopCh:
 			}
 		} else {

--- a/replication.go
+++ b/replication.go
@@ -364,7 +364,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 	}
 }
 
-// shutdown is used to signal the followers that the leader is shutting down.
+// sendShutdown is used to signal the followers that the leader is shutting down.
 // This way they don't have to wait for HeartbeatTimeout to start an election.
 func (r *Raft) sendShutdown(s *followerReplication) {
 	req := AppendEntriesRequest{

--- a/util.go
+++ b/util.go
@@ -116,11 +116,13 @@ func encodeMsgPack(in interface{}) (*bytes.Buffer, error) {
 // backoff is used to compute an exponential backoff
 // duration. Base time is scaled by the current round,
 // up to some maximum scale factor.
-func backoff(base time.Duration, round, limit uint64) time.Duration {
-	power := min(round, limit)
-	for power > 2 {
+func backoff(base, max time.Duration, round uint64) time.Duration {
+	for round > 2 {
 		base *= 2
-		power--
+		round--
+		if base > max {
+			return max
+		}
 	}
 	return base
 }

--- a/util_test.go
+++ b/util_test.go
@@ -80,22 +80,27 @@ func TestGenerateUUID(t *testing.T) {
 }
 
 func TestBackoff(t *testing.T) {
-	b := backoff(10*time.Millisecond, 1, 8)
+	b := backoff(10*time.Millisecond, 640*time.Millisecond, 1)
 	if b != 10*time.Millisecond {
 		t.Fatalf("bad: %v", b)
 	}
 
-	b = backoff(20*time.Millisecond, 2, 8)
+	b = backoff(20*time.Millisecond, 640*time.Millisecond, 2)
 	if b != 20*time.Millisecond {
 		t.Fatalf("bad: %v", b)
 	}
 
-	b = backoff(10*time.Millisecond, 8, 8)
+	b = backoff(20*time.Millisecond, 640*time.Millisecond, 3)
+	if b != 40*time.Millisecond {
+		t.Fatalf("bad: %v", b)
+	}
+
+	b = backoff(10*time.Millisecond, 640*time.Millisecond, 8)
 	if b != 640*time.Millisecond {
 		t.Fatalf("bad: %v", b)
 	}
 
-	b = backoff(10*time.Millisecond, 9, 8)
+	b = backoff(10*time.Millisecond, 640*time.Millisecond, 8)
 	if b != 640*time.Millisecond {
 		t.Fatalf("bad: %v", b)
 	}


### PR DESCRIPTION
I tried to make the commit messages speak for themselves. I made this mainly because I want to be able to kill a node nicely so it can be updated, even if it's the leader. The following are the changes I made (some depend on the ones before):

- Add HeartbeatInterval configuration
- Always accept elections for newer terms
- Allow election timeout to be shorter than heartbeat timeout
- Make maximum backoff duration configurable
- Make just started nodes wait twice the maximum backoff time before starting an election
- Make shutdown graceful by notifying followers

Setting a low heartbeat timeout is not always an option, because this can cause issues when the node is very busy. This way the election timeout can be as low as the network allows, as nodes are not doing anything else during an election. This allows us to set the election timeout to 50ms and when the shutdown is done gracefully this means that the cluster will only have a downtime of something like 200ms.