### PR TITLE
Remove defer for closing files in the snapshot restoration loop in RecoverCluster()

### DIFF
--- a/api.go
+++ b/api.go
@@ -279,12 +279,14 @@ func RecoverCluster(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 			// couldn't open any snapshots.
 			continue
 		}
-		defer source.Close()
 
 		if err := fsm.Restore(source); err != nil {
 			// Same here, skip and try the next one.
+			source.Close()
 			continue
 		}
+
+		source.Close()
 
 		snapshotIndex = snapshot.Index
 		snapshotTerm = snapshot.Term


### PR DESCRIPTION
This fixes #262 .

Because `defer` executes at the very end of the function, in https://github.com/hashicorp/raft/blob/master/api.go#L282, the file handles are not actually closed until the end of the function. 

That means on systems which are quite sensitive to locks like Windows, when the snapshots are reaped in `Close()` here: https://github.com/hashicorp/raft/blob/master/api.go#L333, the file handlers are not closed.

This produces the `The process cannot access the file because it is being used by another process.` error on Windows.

There should probably be some sort of refactoring to encapsulate that piece of logic within the SnapshotStores so that users of the store do not need to take this into account.

cc @slackpad 