### PR TITLE
Incorporate the ServerID in node identity verification.

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -309,11 +309,11 @@ func decodePeers(buf []byte, trans Transport) Configuration {
 	// Deserialize each peer.
 	var servers []Server
 	for _, enc := range encPeers {
-		p := trans.DecodePeer(enc)
+		id, addr := trans.DecodePeer(enc)
 		servers = append(servers, Server{
 			Suffrage: Voter,
-			ID:       ServerID(p),
-			Address:  ServerAddress(p),
+			ID:       ServerID(id),
+			Address:  ServerAddress(addr),
 		})
 	}
 

--- a/net_transport_test.go
+++ b/net_transport_test.go
@@ -375,10 +375,13 @@ func TestNetworkTransport_EncodeDecode(t *testing.T) {
 
 	local := trans1.LocalAddr()
 	enc := trans1.EncodePeer("id1", local)
-	dec := trans1.DecodePeer(enc)
+	decID, decAddr := trans1.DecodePeer(enc)
 
-	if dec != local {
-		t.Fatalf("enc/dec fail: %v %v", dec, local)
+	if decID != "id1" {
+		t.Fatalf("enc/dec fail: %v %v", decID, "id1")
+	}
+	if decAddr != local {
+		t.Fatalf("enc/dec fail: %v %v", decAddr, local)
 	}
 }
 
@@ -393,10 +396,13 @@ func TestNetworkTransport_EncodeDecode_AddressProvider(t *testing.T) {
 
 	local := trans1.LocalAddr()
 	enc := trans1.EncodePeer("id1", local)
-	dec := trans1.DecodePeer(enc)
+	decID, decAddr := trans1.DecodePeer(enc)
 
-	if dec != ServerAddress(addressOverride) {
-		t.Fatalf("enc/dec fail: %v %v", dec, addressOverride)
+	if decID != "id1" {
+		t.Fatalf("enc/dec fail: %v %v", decID, "id1")
+	}
+	if decAddr != ServerAddress(addressOverride) {
+		t.Fatalf("enc/dec fail: %v %v", decAddr, addressOverride)
 	}
 }
 

--- a/observer.go
+++ b/observer.go
@@ -15,7 +15,8 @@ type Observation struct {
 
 // LeaderObservation is used for the data when leadership changes.
 type LeaderObservation struct {
-	leader ServerAddress
+	leaderID      ServerID
+	leaderAddress ServerAddress
 }
 
 // nextObserverId is used to provide a unique ID for each observer to aid in

--- a/raft_test.go
+++ b/raft_test.go
@@ -462,15 +462,15 @@ func (c *cluster) EnsureLeader(t *testing.T, expect ServerAddress) {
 	// think the leader is correct
 	fail := false
 	for _, r := range c.rafts {
-		leader := ServerAddress(r.Leader())
-		if leader != expect {
-			if leader == "" {
-				leader = "[none]"
+		_, leaderAddr := r.Leader()
+		if leaderAddr != expect {
+			if leaderAddr == "" {
+				leaderAddr = "[none]"
 			}
 			if expect == "" {
-				c.logger.Printf("[ERR] Peer %s sees leader %v expected [none]", r, leader)
+				c.logger.Printf("[ERR] Peer %s sees leader %v expected [none]", r, leaderAddr)
 			} else {
-				c.logger.Printf("[ERR] Peer %s sees leader %v expected %v", r, leader, expect)
+				c.logger.Printf("[ERR] Peer %s sees leader %v expected %v", r, leaderAddr, expect)
 			}
 			fail = true
 		}
@@ -2044,11 +2044,11 @@ func TestRaft_LeaderLeaseExpire(t *testing.T) {
 	}
 
 	// Ensure both have cleared their leader
-	if l := leader.Leader(); l != "" {
-		c.FailNowf("[ERR] bad: %v", l)
+	if id, addr := leader.Leader(); id != "" || addr != "" {
+		c.FailNowf("[ERR] bad: %v %v", id, addr)
 	}
-	if l := follower.Leader(); l != "" {
-		c.FailNowf("[ERR] bad: %v", l)
+	if id, addr := follower.Leader(); id != "" || addr != "" {
+		c.FailNowf("[ERR] bad: %v %v", id, addr)
 	}
 }
 
@@ -2139,8 +2139,8 @@ func TestRaft_VerifyLeader_Fail(t *testing.T) {
 	}
 
 	// Ensure the known leader is cleared
-	if l := leader.Leader(); l != "" {
-		c.FailNowf("[ERR] bad: %v", l)
+	if id, addr := leader.Leader(); id != "" || addr != "" {
+		c.FailNowf("[ERR] bad: %v %v", id, addr)
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -51,7 +51,7 @@ type Transport interface {
 	EncodePeer(id ServerID, addr ServerAddress) []byte
 
 	// DecodePeer is used to deserialize a peer's address.
-	DecodePeer([]byte) ServerAddress
+	DecodePeer([]byte) (ServerID, ServerAddress)
 
 	// SetHeartbeatHandler is used to setup a heartbeat handler
 	// as a fast-pass. This is to avoid head-of-line blocking from

--- a/transport_test.go
+++ b/transport_test.go
@@ -303,10 +303,13 @@ func TestTransport_EncodeDecode(t *testing.T) {
 
 		local := trans1.LocalAddr()
 		enc := trans1.EncodePeer("aaaa", local)
-		dec := trans1.DecodePeer(enc)
+		decID, decAddr := trans1.DecodePeer(enc)
 
-		if dec != local {
-			t.Fatalf("enc/dec fail: %v %v", dec, local)
+		if decID != "aaaa" {
+			t.Fatalf("enc/dec fail: %v %v", decID, "aaaa")
+		}
+		if decAddr != local {
+			t.Fatalf("enc/dec fail: %v %v", decAddr, local)
 		}
 	}
 }


### PR DESCRIPTION
* encode/decode ServerID in transports
* track the leader ServerID
* use the leader ServerID as a second identifier

Votes will be rejected when `candidate(id,addr)` doesn't match up with `leader(id,addr)`. The reasoning here is that a change of the ServerID or the ServerAddress indicates a change in the peer process (This is especially important in more dynamic environments like kubernetes where address can be reused by different nodes).

I'm aware of the library-v2-stage-two branch but it seems to be lagging behind. Feel free to reject this PR.