### PR TITLE
Fix race between AppendEntriesPipeline and Disconnect in InmemTransport

### DIFF
--- a/inmem_transport.go
+++ b/inmem_transport.go
@@ -76,16 +76,15 @@ func (i *InmemTransport) LocalAddr() ServerAddress {
 // AppendEntriesPipeline returns an interface that can be used to pipeline
 // AppendEntries requests.
 func (i *InmemTransport) AppendEntriesPipeline(id ServerID, target ServerAddress) (AppendPipeline, error) {
-	i.RLock()
+	i.Lock()
+	defer i.Unlock()
+
 	peer, ok := i.peers[target]
-	i.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("failed to connect to peer: %v", target)
 	}
 	pipeline := newInmemPipeline(i, peer, target)
-	i.Lock()
 	i.pipelines = append(i.pipelines, pipeline)
-	i.Unlock()
 	return pipeline, nil
 }
 


### PR DESCRIPTION
Acquire the write lock unconditionally at the beginning of
AppendEntriesPipeline, to prevent Disconnect from racing with it by
deleting a peer inbetween the read and write lock.

With this fix the sample program attached to #273 does not fail anymore.