### PR TITLE
Make the InmemTransport.timeout field configurable

### DIFF
--- a/inmem_transport.go
+++ b/inmem_transport.go
@@ -43,9 +43,11 @@ type InmemTransport struct {
 	timeout    time.Duration
 }
 
-// NewInmemTransport is used to initialize a new transport
-// and generates a random local address if none is specified
-func NewInmemTransport(addr ServerAddress) (ServerAddress, *InmemTransport) {
+// NewInmemTransportWithTimeout is used to initialize a new transport and
+// generates a random local address if none is specified. The given timeout
+// will be used to decide how long to wait for a connected peer to process the
+// RPCs that we're sending it. See also Connect() and Consumer().
+func NewInmemTransportWithTimeout(addr ServerAddress, timeout time.Duration) (ServerAddress, *InmemTransport) {
 	if string(addr) == "" {
 		addr = NewInmemAddr()
 	}
@@ -53,9 +55,15 @@ func NewInmemTransport(addr ServerAddress) (ServerAddress, *InmemTransport) {
 		consumerCh: make(chan RPC, 16),
 		localAddr:  addr,
 		peers:      make(map[ServerAddress]*InmemTransport),
-		timeout:    50 * time.Millisecond,
+		timeout:    timeout,
 	}
 	return addr, trans
+}
+
+// NewInmemTransport is used to initialize a new transport
+// and generates a random local address if none is specified
+func NewInmemTransport(addr ServerAddress) (ServerAddress, *InmemTransport) {
+	return NewInmemTransportWithTimeout(addr, 50*time.Millisecond)
 }
 
 // SetHeartbeatHandler is used to set optional fast-path for


### PR DESCRIPTION
The NewInmemTransportWithTimeout contructor supports specifying a
custom RPC timeout for an InmemTransport instance.

This timeout appears to be the only non-configurable one when creating
test-oriented Raft instances (i.e. using the in-memory version of the
various dependencies). All other timeouts can be set using Config.

Being able to tweak this timeout is useful when running tests on
machines under relatively high load, where a low timeout might produce
spurious errors.