### PR TITLE
InmemStore.Get should error on nil value

### DIFF
--- a/inmem_store.go
+++ b/inmem_store.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"errors"
 	"sync"
 )
 
@@ -107,7 +108,7 @@ func (i *InmemStore) Get(key []byte) ([]byte, error) {
 	i.l.RLock()
 	defer i.l.RUnlock()
 	val := i.kv[string(key)]
-        if val == nil {
+	if val == nil {
 		return nil, errors.New("not found")
 	}
 	return val, nil

--- a/inmem_store.go
+++ b/inmem_store.go
@@ -106,7 +106,11 @@ func (i *InmemStore) Set(key []byte, val []byte) error {
 func (i *InmemStore) Get(key []byte) ([]byte, error) {
 	i.l.RLock()
 	defer i.l.RUnlock()
-	return i.kv[string(key)], nil
+	val := i.kv[string(key)]
+        if val == nil {
+		return nil, errors.New("not found")
+	}
+	return val, nil
 }
 
 // SetUint64 implements the StableStore interface.


### PR DESCRIPTION
InmemStore implements the LogStore and StableStore interface.
However it's implementation of the StableStore interface Get method has a bug. 

If you look at the hashicorp/raft-boltdb[1] and hashicorp/raft-mdb[2] implementation of the same method; 
then if a get for a key returns a nil byte, that method should return an error. 

Since InmemStore is mostly used in tests, it's implementation should be aligned with raft-boltdb raft-mdb so as not hide any errors

ref:
1. https://github.com/hashicorp/raft-boltdb/blob/6e5ba93211eaf8d9a2ad7e41ffad8c6f160f9fe3/bolt_store.go#L241-L246
2. https://github.com/hashicorp/raft-mdb/blob/55f29473b9e604b3678b93a8433a6cf089e70f76/mdb_store.go#L328-L330