### PR TITLE
Make the logging more generic

### DIFF
--- a/api.go
+++ b/api.go
@@ -50,6 +50,20 @@ var (
 	ErrCantBootstrap = errors.New("bootstrap only works on new clusters")
 )
 
+type Logger interface {
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Fatalln(args ...interface{})
+
+	Panic(args ...interface{})
+	Panicf(format string, args ...interface{})
+	Panicln(args ...interface{})
+
+	Print(args ...interface{})
+	Printf(format string, args ...interface{})
+	Println(args ...interface{})
+}
+
 // Raft implements a Raft node.
 type Raft struct {
 	raftState
@@ -103,7 +117,7 @@ type Raft struct {
 	localAddr ServerAddress
 
 	// Used for our logging
-	logger *log.Logger
+	logger Logger
 
 	// LogStore provides durable storage for logs
 	logs LogStore
@@ -394,7 +408,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	}
 
 	// Ensure we have a LogOutput.
-	var logger *log.Logger
+	var logger Logger
 	if conf.Logger != nil {
 		logger = conf.Logger
 	} else {

--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package raft
 import (
 	"fmt"
 	"io"
-	"log"
 	"time"
 )
 
@@ -192,7 +191,7 @@ type Config struct {
 
 	// Logger is a user-provided logger. If nil, a logger writing to LogOutput
 	// is used.
-	Logger *log.Logger
+	Logger Logger
 }
 
 // DefaultConfig returns a Config with usable defaults.


### PR DESCRIPTION
Replace the log.Logger struct by a more generic way to log and permit users to choose their own logging method. 