### PR TITLE
Correct docs on value of state

### DIFF
--- a/api.go
+++ b/api.go
@@ -914,8 +914,9 @@ func (r *Raft) LastContact() time.Time {
 // "last_snapshot_index", "last_snapshot_term",
 // "latest_configuration", "last_contact", and "num_peers".
 //
-// The value of "state" is a numerical value representing a
-// RaftState const.
+// The value of "state" is the string representation of the
+// RaftState const. This can be "Follower", "Candidate",
+// "Leader" or "Shutdown".
 //
 // The value of "latest_configuration" is a string which contains
 // the id of each server, its suffrage status, and its address.


### PR DESCRIPTION
It's not true that "state" contains a numerical value. It contains the string representation of the RaftState.

Thanks @JelteF for the origina PR in #214. I have rebased your change on top of master.