### PR TITLE
Update Docs to remove "better" #299

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,7 +38,8 @@ import (
 //
 // 1. Remove the server from the cluster with RemoveServer, using its network
 //    address as its ServerID.
-// 2. Update the server's config to a better ID (restarting the server).
+// 2. Update the server's config to use a UUID or something else that is
+//	  not tied to the machine as the ServerID (restarting the server).
 // 3. Add the server back to the cluster with AddVoter, using its new ID.
 //
 // You can do this during the rolling upgrade from N+1 to N+2 of your app, or


### PR DESCRIPTION
Removing the usage of "better" to be more explicit in stating we use the ServerAddress instead of the network address. 