### PR TITLE
adds peer changes to observations.

### DIFF
--- a/observer.go
+++ b/observer.go
@@ -9,13 +9,22 @@ type Observation struct {
 	// Raft holds the Raft instance generating the observation.
 	Raft *Raft
 	// Data holds observation-specific data. Possible types are
-	// *RequestVoteRequest and RaftState.
+	// *RequestVoteRequest
+	// RaftState
+	// PeerObservation
+	// LeaderObservation
 	Data interface{}
 }
 
 // LeaderObservation is used for the data when leadership changes.
 type LeaderObservation struct {
 	leader ServerAddress
+}
+
+// PeerObservation is sent to observers when peers change.
+type PeerObservation struct {
+	Removed bool
+	Peer    Server
 }
 
 // nextObserverId is used to provide a unique ID for each observer to aid in

--- a/raft.go
+++ b/raft.go
@@ -450,6 +450,7 @@ func (r *Raft) startStopReplication() {
 			r.leaderState.replState[server.ID] = s
 			r.goFunc(func() { r.replicate(s) })
 			asyncNotifyCh(s.triggerCh)
+			r.observe(PeerObservation{Peer: server, Removed: false})
 		}
 	}
 
@@ -463,6 +464,7 @@ func (r *Raft) startStopReplication() {
 		repl.stopCh <- lastIdx
 		close(repl.stopCh)
 		delete(r.leaderState.replState, serverID)
+		r.observe(PeerObservation{Peer: repl.peer, Removed: true})
 	}
 }
 


### PR DESCRIPTION
allows for reactions to peers changing. I've decided against heart beats and contact failures due to their high volume for the time being. though a simple rate limit on emission would resolve any issues there.

related to: #249

@RobbieMcKinstry 