### PR TITLE
chore: Add probot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -20,8 +20,10 @@ staleLabel: "waiting-reply"
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: |
   Hey there,
-  We wanted to check in on this request since it has been inactive for 90 days. 
-  Are you having the same issue with the latest version of Raft? Have you reviewed the latest [godocs](https://godoc.org/github.com/hashicorp/raft)? 
+  We wanted to check in on this request since it has been inactive for at least 90 days.
+  Have you reviewed the latest [godocs](https://godoc.org/github.com/hashicorp/raft)? 
+  If you think this is still an important issue in the latest version of [the Raft library](https://github.com/hashicorp/raft/compare/) or 
+  [its documentation](https://github.com/hashicorp/raft/compare/) please feel let us know and we'll keep it open for investigation.
   If there is still no activity on this request in 30 days, we will go ahead and close it.
   Thank you!
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -20,10 +20,9 @@ staleLabel: "waiting-reply"
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: |
   Hey there,
-  This issues hasn't had any activity for a while, so we're going to
-  automatically close it in 30 days. If you're still seeing this issue with the
-  latest version of Raft, please respond here and we'll keep it open and take
-  another look at this.
+  We wanted to check in on this request since it has been inactive for 90 days. 
+  Are you having the same issue with the latest version of Raft? Have you reviewed the latest [godocs](https://godoc.org/github.com/hashicorp/raft)? 
+  If there is still no activity on this request in 30 days, we will go ahead and close it.
   Thank you!
 
 # Comment to post when removing the stale label. Set to `false` to disable
@@ -32,8 +31,8 @@ unmarkComment: false
 # Comment to post when closing a stale Issue. Set to `false` to disable
 closeComment: >
   Hey there,
-  This issue has been automatically closed because there hasn't been any activity for a while.
-  Feel free to [open a new one](https://github.com/hashicorp/raft/issues/new) if you still experience this problem :+1:
+  This issue has been automatically closed because there hasn't been any activity for a while. 
+  If you are still experiencing problems, or still have questions, feel free to [open a new one](https://github.com/hashicorp/raft/issues/new) :+1
 
 # Limit to only `issues`
 only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,39 @@
+# Number of days of inactivity before an Issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Issues with these labels will never be considered stale. Set to `[]` to disable
+# We don't close any issue that is an enhancement or confirmed bug, but issues
+# waiting for reproduction cases and questions tend to get outdated.
+exemptLabels:
+  - "enhancement"
+  - "bug"
+  - "thinking"
+  - "docs"
+
+# Label to use when marking as stale
+staleLabel: "waiting-reply"
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: |
+  Hey there,
+  This issues hasn't had any activity for a while, so we're going to
+  automatically close it in 30 days. If you're still seeing this issue with the
+  latest version of Raft, please respond here and we'll keep it open and take
+  another look at this.
+  Thank you!
+
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+
+# Comment to post when closing a stale Issue. Set to `false` to disable
+closeComment: >
+  Hey there,
+  This issue has been automatically closed because there hasn't been any activity for a while.
+  Feel free to [open a new one](https://github.com/hashicorp/raft/issues/new) if you still experience this problem :+1:
+
+# Limit to only `issues`
+only: issues


### PR DESCRIPTION
This is a first draft at a GitHub Probot configuration for managing those issues
with a long enough cycle time that it shouldn't catch cases where there is
active discussion, and it'll ignore anything we've explicitly called out an
enhancement, bug, or docs change, but will prompt people for a response if
we're waiting-reply etc.

I'm especially looking for feedback on the language usage, because I think the
thresholds are about correct for the volume on this repo.

Link to source/docs: https://github.com/probot/stale