### PR TITLE
Add circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,12 @@ jobs:
         type: string
     docker:
       - image: << parameters.go-version >>
+    environment: *ENVIRONMENT
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS_DIR
 
-      - restore_cache: # restore cache from dev-build job
+      - restore_cache: # restore cache
           keys:
             - raft-modcache-v1-{{ checksum "go.mod" }}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,9 @@ jobs:
               echo "$files"
               exit 1
             fi
-      - run: go vet ./...
+      - run: |
+          PACKAGE_NAMES=$(go list ./... | grep -v github.com/hashicorp/raft/fuzzy)
+          go vet $PACKAGE_NAMES
 
   go-test:
     description: Runs go tests
@@ -59,7 +61,7 @@ jobs:
 
       # run go tests with gotestsum
       - run: |
-          PACKAGE_NAMES=$(go list ./...)
+          PACKAGE_NAMES=$(go list ./... | grep -v github.com/hashicorp/raft/fuzzy)
           gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- $PACKAGE_NAMES
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,14 +75,17 @@ workflows:
     jobs:
       - go-fmt-and-vet
       - go-test:
+          name: test go1.10
           go-version: *GOLANG_1_10_IMAGE
           requires:
             - go-fmt-and-vet
       - go-test:
+          name: test go1.11
           go-version: *GOLANG_1_11_IMAGE
           requires:
             - go-fmt-and-vet
       - go-test:
+          name: test go1.12
           go-version: *GOLANG_1_12_IMAGE
           requires:
             - go-fmt-and-vet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,85 @@
+version: 2.1
+
+references:
+  images:
+    go-1.10: &GOLANG_1_10_IMAGE circleci/golang:1.10
+    go-1.11: &GOLANG_1_11_IMAGE circleci/golang:1.11
+    go-1.12: &GOLANG_1_12_IMAGE circleci/golang:1.12
+
+  environment: &ENVIRONMENT
+    TEST_RESULTS_DIR: &TEST_RESULTS_DIR /tmp/test-results # path to where test results are saved
+
+jobs:
+  go-fmt-and-vet:
+    docker:
+      - image: *GOLANG_1_12_IMAGE
+    steps:
+      - checkout
+
+      # Restore go module cache if there is one
+      - restore_cache:
+          keys:
+            - raft-modcache-v1-{{ checksum "go.mod" }}
+
+      - run: go mod download
+
+      # Save go module cache if the go.mod file has changed
+      - save_cache:
+          key: raft-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+            - "/go/pkg/mod"
+
+      # check go fmt output because it does not report non-zero when there are fmt changes
+      - run:
+          name: check go fmt
+          command: |
+            files=$(go fmt ./...)
+            if [ -n "$files" ]; then
+              echo "The following file(s) do not conform to go fmt:"
+              echo "$files"
+              exit 1
+            fi
+      - run: go vet ./...
+
+  go-test:
+    description: Runs go tests
+    parameters:
+      go-version:
+        description: what go version to use
+        type: string
+    docker:
+      - image: << parameters.go-version >>
+    steps:
+      - checkout
+      - run: mkdir -p $TEST_RESULTS_DIR
+
+      - restore_cache: # restore cache from dev-build job
+          keys:
+            - raft-modcache-v1-{{ checksum "go.mod" }}
+
+      # run go tests with gotestsum
+      - run: |
+          PACKAGE_NAMES=$(go list ./...)
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- $PACKAGE_NAMES
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+
+workflows:
+  version: 2
+  test-and-build:
+    jobs:
+      - go-fmt-and-vet
+      - go-test:
+          go-version: *GOLANG_1_10_IMAGE
+          requires:
+            - go-fmt-and-vet
+      - go-test:
+          go-version: *GOLANG_1_11_IMAGE
+          requires:
+            - go-fmt-and-vet
+      - go-test:
+          go-version: *GOLANG_1_12_IMAGE
+          requires:
+            - go-fmt-and-vet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 references:
   images:
-    go-1.10: &GOLANG_1_10_IMAGE circleci/golang:1.10
     go-1.11: &GOLANG_1_11_IMAGE circleci/golang:1.11
     go-1.12: &GOLANG_1_12_IMAGE circleci/golang:1.12
 
@@ -73,11 +72,6 @@ workflows:
   test-and-build:
     jobs:
       - go-fmt-and-vet
-      - go-test:
-          name: test go1.10
-          go-version: *GOLANG_1_10_IMAGE
-          requires:
-            - go-fmt-and-vet
       - go-test:
           name: test go1.11
           go-version: *GOLANG_1_11_IMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ references:
 
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: &TEST_RESULTS_DIR /tmp/test-results # path to where test results are saved
+    GO111MODULE: 'on'
 
 jobs:
   go-fmt-and-vet:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,7 @@ jobs:
             - raft-modcache-v1-{{ checksum "go.mod" }}
 
       # run go tests with gotestsum
-      - run: |
-          PACKAGE_NAMES=$(go list ./... | grep -v github.com/hashicorp/raft/fuzzy)
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- $PACKAGE_NAMES
+      - run: make ci.integ
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
+TEST_RESULTS_DIR?=/tmp/test-results
 
 test:
 	go test -timeout=60s -race .
@@ -6,9 +7,15 @@ test:
 integ: test
 	INTEG_TESTS=yes go test -timeout=25s -run=Integ .
 
+ci.test:
+	gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-test.xml -- -timeout=60s -race .
+
+ci.integ: ci.test
+	INTEG_TESTS=yes gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-integ.xml -- -timeout=25s -run=Integ .
+
 fuzz:
 	go test -timeout=300s ./fuzzy
-	
+
 deps:
 	go get -t -d -v ./...
 	echo $(DEPS) | xargs -n1 go get -d

--- a/api.go
+++ b/api.go
@@ -934,7 +934,7 @@ func (r *Raft) LastContact() time.Time {
 // "last_snapshot_index", "last_snapshot_term",
 // "latest_configuration", "last_contact", and "num_peers".
 //
-// The value of "state" is a numeric constant representing one of 
+// The value of "state" is a numeric constant representing one of
 // the possible leadership states the node is in at any given time.
 // the possible states are: "Follower", "Candidate", "Leader", "Shutdown".
 //

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.12
 
 require (
 	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878
+	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/hashicorp/go-hclog v0.9.1
 	github.com/hashicorp/go-msgpack v0.5.5
+	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 h1:EFSB7Zo9Eg91v7MJPVsifUysc/wPdN+NOnVe6bWbdBM=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
+github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,10 +18,14 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea h1:xykPFhrBAS2J0VBzVa5e80b5ZtYuNQtgXjN40qBZlD4=
+github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pNv7Wc3ycL6F5oOWn+tPGo2gWD4a5X+yp/ntwdKLjRk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -35,3 +41,5 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5 h1:sM3evRHxE/1RuMe1FYAL3j7C7fUfIjkbE+NiDAYUF8U=
+golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/net_transport_test.go
+++ b/net_transport_test.go
@@ -705,7 +705,7 @@ func makeTransport(t *testing.T, useAddrProvider bool, addressOverride string) (
 }
 
 type testCountingWriter struct {
-	t *testing.T
+	t        *testing.T
 	numCalls *int32
 }
 
@@ -739,7 +739,6 @@ func (sl testCountingStreamLayer) Dial(address ServerAddress, timeout time.Durat
 	return nil, fmt.Errorf("not needed")
 }
 
-
 // TestNetworkTransport_ListenBackoff tests that Accept() errors in NetworkTransport#listen()
 // do not result in a tight loop and spam the log. We verify this here by counting the number
 // of calls against Accept() and the logger
@@ -755,8 +754,8 @@ func TestNetworkTransport_ListenBackoff(t *testing.T) {
 	countingWriter := testCountingWriter{t, &numLogs}
 	countingLogger := log.New(countingWriter, "test", log.LstdFlags)
 	transport := NetworkTransport{
-		logger: countingLogger,
-		stream: testCountingStreamLayer{&numAccepts},
+		logger:     countingLogger,
+		stream:     testCountingStreamLayer{&numAccepts},
 		shutdownCh: make(chan struct{}),
 	}
 
@@ -769,7 +768,7 @@ func TestNetworkTransport_ListenBackoff(t *testing.T) {
 	// Verify that the method exited (but without block this test)
 	// maxDelay == 1s, so we will give the routine 1.25s to loop around and shut down.
 	select {
-	case <- transport.shutdownCh:
+	case <-transport.shutdownCh:
 	case <-time.After(1250 * time.Millisecond):
 		t.Error("timed out waiting for NetworkTransport to shut down")
 	}


### PR DESCRIPTION
I removed the test for go1.10 since it does not have the `go mod` subcommands and would need to go back to the vendor route. Not hugely difficult but I can add that back later if we want to support it. 