### PR TITLE
Clarify the BootstrapCluster behaviour and error expectation

### DIFF
--- a/api.go
+++ b/api.go
@@ -591,10 +591,17 @@ func (r *Raft) restoreSnapshot() error {
 
 // BootstrapCluster is equivalent to non-member BootstrapCluster but can be
 // called on an un-bootstrapped Raft instance after it has been created. This
-// should only be called at the beginning of time for the cluster, and you
-// absolutely must make sure that you call it with the same configuration on all
-// the Voter servers. There is no need to bootstrap Nonvoter and Staging
-// servers.
+// should only be called at the beginning of time for the cluster with a
+// configuration listing all Voter servers. There is no need to bootstrap
+// Nonvoter and Staging servers.
+//
+// A cluster can only be bootstrapped once from a single participating Voter
+// server. Any further attempts to bootstrap will return an error that can be
+// safely ignored.
+//
+// One sane approach is to bootstrap a single server with a configuration
+// listing just itself as a Voter, then invoke AddVoter() on it to add other
+// servers to the cluster.
 func (r *Raft) BootstrapCluster(configuration Configuration) Future {
 	bootstrapReq := &bootstrapFuture{}
 	bootstrapReq.init()

--- a/api.go
+++ b/api.go
@@ -175,8 +175,8 @@ type Raft struct {
 
 // BootstrapCluster initializes a server's storage with the given cluster
 // configuration. This should only be called at the beginning of time for the
-// cluster with a configuration listing all Voter servers. There is no need to
-// bootstrap Nonvoter and Staging servers.
+// cluster with an identical configuration listing all Voter servers. There is
+// no need to bootstrap Nonvoter and Staging servers.
 //
 // A cluster can only be bootstrapped once from a single participating Voter
 // server. Any further attempts to bootstrap will return an error that can be
@@ -591,9 +591,9 @@ func (r *Raft) restoreSnapshot() error {
 
 // BootstrapCluster is equivalent to non-member BootstrapCluster but can be
 // called on an un-bootstrapped Raft instance after it has been created. This
-// should only be called at the beginning of time for the cluster with a
-// configuration listing all Voter servers. There is no need to bootstrap
-// Nonvoter and Staging servers.
+// should only be called at the beginning of time for the cluster with an
+// identical configuration listing all Voter servers. There is no need to
+// bootstrap Nonvoter and Staging servers.
 //
 // A cluster can only be bootstrapped once from a single participating Voter
 // server. Any further attempts to bootstrap will return an error that can be

--- a/api.go
+++ b/api.go
@@ -175,9 +175,12 @@ type Raft struct {
 
 // BootstrapCluster initializes a server's storage with the given cluster
 // configuration. This should only be called at the beginning of time for the
-// cluster, and you absolutely must make sure that you call it with the same
-// configuration on all the Voter servers. There is no need to bootstrap
-// Nonvoter and Staging servers.
+// cluster with a configuration listing all Voter servers. There is no need to
+// bootstrap Nonvoter and Staging servers.
+//
+// A cluster can only be bootstrapped once from a single participating Voter
+// server. Any further attempts to bootstrap will return an error that can be
+// safely ignored.
 //
 // One sane approach is to bootstrap a single server with a configuration
 // listing just itself as a Voter, then invoke AddVoter() on it to add other


### PR DESCRIPTION
This PR aims to resolve #336.

With clarification from @RobbieMcKinstry, this PR includes the following clarifications:

- The sentence "you absolutely must make sure that you call it with the same configuration on all the Voter servers" has been completely removed. The actual meaning of this sentence was "If you are going to call it on all Voter servers, it must be with the same configuration". However, it reads as "This method _must_ be called on all Voter servers for the bootstrap process to work", which is incorrect. Instead, that sentence now clarifies that on any voting server that calls `BootstrapCluster`, the configuration must be identical.

- There is also a small additional paragraph that says that the cluster can only be bootstrapped from a single Voter server (which is true). It also says that any further attempts to bootstrap can be safely ignored. The combination of these two remarks provides the necessary inference (without the potential to mislead), along with the change in the first paragraph, that it may be called on all participating Voter servers, _as long_ as they all have the same configuration, and that the error from subsequent calls can be ignored.

- This documentation is also completely cloned to the other Raft instance `BootstrapCluster` method for completeness.

Hope this is all OK and makes sense, please let me know if you have any questions about my rationale here! 😄 