### PR TITLE
Break out of group commit early.

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -725,12 +725,13 @@ func (r *Raft) leaderLoop() {
 			}
 			// Group commit, gather all the ready commits
 			ready := []*logFuture{newLog}
+		GROUP_COMMIT_LOOP:
 			for i := 0; i < r.conf.MaxAppendEntries; i++ {
 				select {
 				case newLog := <-r.applyCh:
 					ready = append(ready, newLog)
 				default:
-					break
+					break GROUP_COMMIT_LOOP
 				}
 			}
 


### PR DESCRIPTION
This is a very minor optimisation to not waste a few cycles re-checking the applyCh for new logs up to 64 times when none are present. Thanks to @weiwei04 in #153 for pointing it out.