### PR TITLE
Updates around linting errors, formatting, and more.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -35,7 +35,7 @@ type AppendEntriesRequest struct {
 	LeaderCommitIndex uint64
 }
 
-// See WithRPCHeader.
+// GetRPCHeader - See WithRPCHeader.
 func (r *AppendEntriesRequest) GetRPCHeader() RPCHeader {
 	return r.RPCHeader
 }
@@ -59,7 +59,7 @@ type AppendEntriesResponse struct {
 	NoRetryBackoff bool
 }
 
-// See WithRPCHeader.
+// GetRPCHeader - See WithRPCHeader.
 func (r *AppendEntriesResponse) GetRPCHeader() RPCHeader {
 	return r.RPCHeader
 }
@@ -83,7 +83,7 @@ type RequestVoteRequest struct {
 	LeadershipTransfer bool
 }
 
-// See WithRPCHeader.
+// GetRPCHeader - See WithRPCHeader.
 func (r *RequestVoteRequest) GetRPCHeader() RPCHeader {
 	return r.RPCHeader
 }
@@ -104,7 +104,7 @@ type RequestVoteResponse struct {
 	Granted bool
 }
 
-// See WithRPCHeader.
+// GetRPCHeader - See WithRPCHeader.
 func (r *RequestVoteResponse) GetRPCHeader() RPCHeader {
 	return r.RPCHeader
 }
@@ -136,7 +136,7 @@ type InstallSnapshotRequest struct {
 	Size int64
 }
 
-// See WithRPCHeader.
+// GetRPCHeader - See WithRPCHeader.
 func (r *InstallSnapshotRequest) GetRPCHeader() RPCHeader {
 	return r.RPCHeader
 }
@@ -150,7 +150,7 @@ type InstallSnapshotResponse struct {
 	Success bool
 }
 
-// See WithRPCHeader.
+// GetRPCHeader - See WithRPCHeader.
 func (r *InstallSnapshotResponse) GetRPCHeader() RPCHeader {
 	return r.RPCHeader
 }
@@ -161,7 +161,7 @@ type TimeoutNowRequest struct {
 	RPCHeader
 }
 
-// See WithRPCHeader.
+// GetRPCHeader - See WithRPCHeader.
 func (r *TimeoutNowRequest) GetRPCHeader() RPCHeader {
 	return r.RPCHeader
 }
@@ -171,7 +171,7 @@ type TimeoutNowResponse struct {
 	RPCHeader
 }
 
-// See WithRPCHeader.
+// GetRPCHeader - See WithRPCHeader.
 func (r *TimeoutNowResponse) GetRPCHeader() RPCHeader {
 	return r.RPCHeader
 }

--- a/config.go
+++ b/config.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-// These are the versions of the protocol (which includes RPC messages as
-// well as Raft-specific log entries) that this server can _understand_. Use
+// ProtocolVersion is the version of the protocol (which includes RPC messages
+// as well as Raft-specific log entries) that this server can _understand_. Use
 // the ProtocolVersion member of the Config object to control the version of
 // the protocol to use when _speaking_ to other servers. Note that depending on
 // the protocol version being spoken, some otherwise understood RPC messages
@@ -88,13 +88,15 @@ import (
 type ProtocolVersion int
 
 const (
+	// ProtocolVersionMin is the minimum protocol version
 	ProtocolVersionMin ProtocolVersion = 0
-	ProtocolVersionMax                 = 3
+	// ProtocolVersionMax is the maximum protocol version
+	ProtocolVersionMax = 3
 )
 
-// These are versions of snapshots that this server can _understand_. Currently,
-// it is always assumed that this server generates the latest version, though
-// this may be changed in the future to include a configurable version.
+// SnapshotVersion is the version of snapshots that this server can understand.
+// Currently, it is always assumed that the server generates the latest version,
+// though this may be changed in the future to include a configurable version.
 //
 // Version History
 //
@@ -112,8 +114,10 @@ const (
 type SnapshotVersion int
 
 const (
+	// SnapshotVersionMin is the minimum snapshot version
 	SnapshotVersionMin SnapshotVersion = 0
-	SnapshotVersionMax                 = 1
+	// SnapshotVersionMax is the maximum snapshot version
+	SnapshotVersionMax = 1
 )
 
 // Config provides any necessary configuration for the Raft server.

--- a/discard_snapshot.go
+++ b/discard_snapshot.go
@@ -12,6 +12,11 @@ import (
 // suitable for testing.
 type DiscardSnapshotStore struct{}
 
+// DiscardSnapshotSink is used to fulfill the SnapshotSink interface
+// while always discarding the . This is useful for when the log
+// should be truncated but no snapshot should be retained. This
+// should never be used for production use, and is only suitable
+// for testing.
 type DiscardSnapshotSink struct{}
 
 // NewDiscardSnapshotStore is used to create a new DiscardSnapshotStore.
@@ -19,31 +24,41 @@ func NewDiscardSnapshotStore() *DiscardSnapshotStore {
 	return &DiscardSnapshotStore{}
 }
 
+// Create returns a valid type implementing the SnapshotSink which
+// always discards the snapshot.
 func (d *DiscardSnapshotStore) Create(version SnapshotVersion, index, term uint64,
 	configuration Configuration, configurationIndex uint64, trans Transport) (SnapshotSink, error) {
 	return &DiscardSnapshotSink{}, nil
 }
 
+// List returns successfully with a nil for []*SnapshotMeta.
 func (d *DiscardSnapshotStore) List() ([]*SnapshotMeta, error) {
 	return nil, nil
 }
 
+// Open returns an error since the DiscardSnapshotStore does not
+// support opening snapshots.
 func (d *DiscardSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error) {
 	return nil, nil, fmt.Errorf("open is not supported")
 }
 
+// Write returns successfully with the lenght of the input byte slice
+// to satisfy the WriteCloser interface
 func (d *DiscardSnapshotSink) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
+// Close returns a nil error
 func (d *DiscardSnapshotSink) Close() error {
 	return nil
 }
 
+// ID returns "discard" for DiscardSnapshotSink
 func (d *DiscardSnapshotSink) ID() string {
 	return "discard"
 }
 
+// Cancel returns successfully with a nil error
 func (d *DiscardSnapshotSink) Cancel() error {
 	return nil
 }

--- a/future.go
+++ b/future.go
@@ -184,7 +184,6 @@ func (u *userSnapshotFuture) Open() (*SnapshotMeta, io.ReadCloser, error) {
 	if u.opener == nil {
 		return nil, nil, fmt.Errorf("no snapshot available")
 	}
-
 	// Invalidate the opener so it can't get called multiple times,
 	// which isn't generally safe.
 	defer func() {

--- a/inmem_snapshot.go
+++ b/inmem_snapshot.go
@@ -100,10 +100,12 @@ func (s *InmemSnapshotSink) Close() error {
 	return nil
 }
 
+// ID returns the ID of the SnapshotMeta
 func (s *InmemSnapshotSink) ID() string {
 	return s.meta.ID
 }
 
+// Cancel returns successfully with a nil error
 func (s *InmemSnapshotSink) Cancel() error {
 	return nil
 }

--- a/log.go
+++ b/log.go
@@ -10,12 +10,12 @@ const (
 	// LogNoop is used to assert leadership.
 	LogNoop
 
-	// LogAddPeer is used to add a new peer. This should only be used with
+	// LogAddPeerDeprecated is used to add a new peer. This should only be used with
 	// older protocol versions designed to be compatible with unversioned
 	// Raft servers. See comments in config.go for details.
 	LogAddPeerDeprecated
 
-	// LogRemovePeer is used to remove an existing peer. This should only be
+	// LogRemovePeerDeprecated is used to remove an existing peer. This should only be
 	// used with older protocol versions designed to be compatible with
 	// unversioned Raft servers. See comments in config.go for details.
 	LogRemovePeerDeprecated

--- a/net_transport.go
+++ b/net_transport.go
@@ -105,6 +105,7 @@ type NetworkTransportConfig struct {
 	Timeout time.Duration
 }
 
+// ServerAddressProvider is a target address to which we invoke an RPC when establishing a connection
 type ServerAddressProvider interface {
 	ServerAddr(id ServerID) (ServerAddress, error)
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	TT_Inmem = iota
+	TTInmem = iota
 
 	// NOTE: must be last
 	numTestTransports
@@ -16,7 +16,7 @@ const (
 
 func NewTestTransport(ttype int, addr ServerAddress) (ServerAddress, LoopbackTransport) {
 	switch ttype {
-	case TT_Inmem:
+	case TTInmem:
 		addr, lt := NewInmemTransport(addr)
 		return addr, lt
 	default:


### PR DESCRIPTION
This provides corrections to comment structure, inclusion of new comments on exported types, explicit aliases on hyphenated imports, renaming of variables that don't follow convention in Go, removal of redundant typing on variable assignment, removed unnecessary else block, etc.

I have yet to dig through `log_cache.go`, which I may knock out tomorrow, but these updates are ready whenever.