### PR TITLE
Replaced logging with hclog throughout raft.

### DIFF
--- a/api.go
+++ b/api.go
@@ -533,8 +533,9 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 		}
 		r.processConfigurationLogEntry(&entry)
 	}
-	r.logger.Info(fmt.Sprintf("Initial configuration (index=%d): %+v",
-		r.configurations.latestIndex, r.configurations.latest.Servers))
+	r.logger.Info("initial configuration",
+		"index", r.configurations.latestIndex,
+		"servers", hclog.Fmt("%+v", r.configurations.latest.Servers))
 
 	// Setup a heartbeat fast-path to avoid head-of-line
 	// blocking where possible. It MUST be safe for this
@@ -554,7 +555,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 func (r *Raft) restoreSnapshot() error {
 	snapshots, err := r.snapshots.List()
 	if err != nil {
-		r.logger.Error(fmt.Sprintf("Failed to list snapshots: %v", err))
+		r.logger.Error("failed to list snapshots", "error", err)
 		return err
 	}
 
@@ -563,7 +564,7 @@ func (r *Raft) restoreSnapshot() error {
 		if !r.conf.NoSnapshotRestoreOnStart {
 			_, source, err := r.snapshots.Open(snapshot.ID)
 			if err != nil {
-				r.logger.Error(fmt.Sprintf("Failed to open snapshot %v: %v", snapshot.ID, err))
+				r.logger.Error("failed to open snapshot", "id", snapshot.ID, "error", err)
 				continue
 			}
 
@@ -571,11 +572,11 @@ func (r *Raft) restoreSnapshot() error {
 			// Close the source after the restore has completed
 			source.Close()
 			if err != nil {
-				r.logger.Error(fmt.Sprintf("Failed to restore snapshot %v: %v", snapshot.ID, err))
+				r.logger.Error("failed to restore snapshot", "id", snapshot.ID, "error", err)
 				continue
 			}
 
-			r.logger.Info(fmt.Sprintf("Restored from snapshot %v", snapshot.ID))
+			r.logger.Info("restored from snapshot", "id", snapshot.ID)
 		}
 		// Update the lastApplied so we don't replay old logs
 		r.setLastApplied(snapshot.Index)

--- a/api.go
+++ b/api.go
@@ -528,7 +528,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	for index := snapshotIndex + 1; index <= lastLog.Index; index++ {
 		var entry Log
 		if err := r.logs.GetLog(index, &entry); err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to get log at %d: %v", index, err))
+			r.logger.Error("failed to get log", "index", index, "error", err)
 			panic(err)
 		}
 		r.processConfigurationLogEntry(&entry)
@@ -1014,7 +1014,7 @@ func (r *Raft) Stats() map[string]string {
 
 	future := r.GetConfiguration()
 	if err := future.Error(); err != nil {
-		r.logger.Warn(fmt.Sprintf("could not get configuration for Stats: %v", err))
+		r.logger.Warn("could not get configuration for stats", "error", err)
 	} else {
 		configuration := future.Configuration()
 		s["latest_configuration_index"] = toString(future.Index())

--- a/file_snapshot.go
+++ b/file_snapshot.go
@@ -5,11 +5,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/go-hclog"
 	"hash"
 	"hash/crc64"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -31,7 +31,7 @@ const (
 type FileSnapshotStore struct {
 	path   string
 	retain int
-	logger *log.Logger
+	logger hclog.Logger
 }
 
 type snapMetaSlice []*fileSnapshotMeta
@@ -39,7 +39,7 @@ type snapMetaSlice []*fileSnapshotMeta
 // FileSnapshotSink implements SnapshotSink with a file.
 type FileSnapshotSink struct {
 	store     *FileSnapshotStore
-	logger    *log.Logger
+	logger    hclog.Logger
 	dir       string
 	parentDir string
 	meta      fileSnapshotMeta
@@ -76,12 +76,16 @@ func (b *bufferedFile) Close() error {
 // NewFileSnapshotStoreWithLogger creates a new FileSnapshotStore based
 // on a base directory. The `retain` parameter controls how many
 // snapshots are retained. Must be at least 1.
-func NewFileSnapshotStoreWithLogger(base string, retain int, logger *log.Logger) (*FileSnapshotStore, error) {
+func NewFileSnapshotStoreWithLogger(base string, retain int, logger hclog.Logger) (*FileSnapshotStore, error) {
 	if retain < 1 {
 		return nil, fmt.Errorf("must retain at least one snapshot")
 	}
 	if logger == nil {
-		logger = log.New(os.Stderr, "", log.LstdFlags)
+		logger = hclog.New(&hclog.LoggerOptions{
+			Name:   "snapshot",
+			Output: hclog.DefaultOutput,
+			Level:  hclog.DefaultLevel,
+		})
 	}
 
 	// Ensure our path exists
@@ -111,7 +115,11 @@ func NewFileSnapshotStore(base string, retain int, logOutput io.Writer) (*FileSn
 	if logOutput == nil {
 		logOutput = os.Stderr
 	}
-	return NewFileSnapshotStoreWithLogger(base, retain, log.New(logOutput, "", log.LstdFlags))
+	return NewFileSnapshotStoreWithLogger(base, retain, hclog.New(&hclog.LoggerOptions{
+		Name:   "snapshot",
+		Output: logOutput,
+		Level:  hclog.DefaultLevel,
+	}))
 }
 
 // testPermissions tries to touch a file in our path to see if it works.
@@ -150,11 +158,11 @@ func (f *FileSnapshotStore) Create(version SnapshotVersion, index, term uint64,
 	// Create a new path
 	name := snapshotName(term, index)
 	path := filepath.Join(f.path, name+tmpSuffix)
-	f.logger.Printf("[INFO] snapshot: Creating new snapshot at %s", path)
+	f.logger.Info("creating new snapshot", "path", path)
 
 	// Make the directory
 	if err := os.MkdirAll(path, 0755); err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to make snapshot directory: %v", err)
+		f.logger.Error("failed to make snapshot directly", "error", err)
 		return nil, err
 	}
 
@@ -180,7 +188,7 @@ func (f *FileSnapshotStore) Create(version SnapshotVersion, index, term uint64,
 
 	// Write out the meta data
 	if err := sink.writeMeta(); err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to write metadata: %v", err)
+		f.logger.Error("failed to write metadata", "error", err)
 		return nil, err
 	}
 
@@ -188,7 +196,7 @@ func (f *FileSnapshotStore) Create(version SnapshotVersion, index, term uint64,
 	statePath := filepath.Join(path, stateFilePath)
 	fh, err := os.Create(statePath)
 	if err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to create state file: %v", err)
+		f.logger.Error("failed to create state file", "error", err)
 		return nil, err
 	}
 	sink.stateFile = fh
@@ -209,7 +217,7 @@ func (f *FileSnapshotStore) List() ([]*SnapshotMeta, error) {
 	// Get the eligible snapshots
 	snapshots, err := f.getSnapshots()
 	if err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to get snapshots: %v", err)
+		f.logger.Error("failed to get snapshots", "error", err)
 		return nil, err
 	}
 
@@ -228,7 +236,7 @@ func (f *FileSnapshotStore) getSnapshots() ([]*fileSnapshotMeta, error) {
 	// Get the eligible snapshots
 	snapshots, err := ioutil.ReadDir(f.path)
 	if err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to scan snapshot dir: %v", err)
+		f.logger.Error("failed to scan snapshot directory", "error", err)
 		return nil, err
 	}
 
@@ -243,20 +251,20 @@ func (f *FileSnapshotStore) getSnapshots() ([]*fileSnapshotMeta, error) {
 		// Ignore any temporary snapshots
 		dirName := snap.Name()
 		if strings.HasSuffix(dirName, tmpSuffix) {
-			f.logger.Printf("[WARN] snapshot: Found temporary snapshot: %v", dirName)
+			f.logger.Warn("found temporary snapshot", "name", dirName)
 			continue
 		}
 
 		// Try to read the meta data
 		meta, err := f.readMeta(dirName)
 		if err != nil {
-			f.logger.Printf("[WARN] snapshot: Failed to read metadata for %v: %v", dirName, err)
+			f.logger.Warn("failed to read metadata", "name", dirName, "error", err)
 			continue
 		}
 
 		// Make sure we can understand this version.
 		if meta.Version < SnapshotVersionMin || meta.Version > SnapshotVersionMax {
-			f.logger.Printf("[WARN] snapshot: Snapshot version for %v not supported: %d", dirName, meta.Version)
+			f.logger.Warn("snapshot version not supported", "name", dirName, "version", meta.Version)
 			continue
 		}
 
@@ -297,7 +305,7 @@ func (f *FileSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error
 	// Get the metadata
 	meta, err := f.readMeta(id)
 	if err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to get meta data to open snapshot: %v", err)
+		f.logger.Error("failed to get meta data to open snapshot", "error", err)
 		return nil, nil, err
 	}
 
@@ -305,7 +313,7 @@ func (f *FileSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error
 	statePath := filepath.Join(f.path, id, stateFilePath)
 	fh, err := os.Open(statePath)
 	if err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to open state file: %v", err)
+		f.logger.Error("failed to open state file", "error", err)
 		return nil, nil, err
 	}
 
@@ -315,7 +323,7 @@ func (f *FileSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error
 	// Compute the hash
 	_, err = io.Copy(stateHash, fh)
 	if err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to read state file: %v", err)
+		f.logger.Error("failed to read state file", "error", err)
 		fh.Close()
 		return nil, nil, err
 	}
@@ -323,15 +331,14 @@ func (f *FileSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error
 	// Verify the hash
 	computed := stateHash.Sum(nil)
 	if bytes.Compare(meta.CRC, computed) != 0 {
-		f.logger.Printf("[ERR] snapshot: CRC checksum failed (stored: %v computed: %v)",
-			meta.CRC, computed)
+		f.logger.Error("CRC checksum failed", "stored", meta.CRC, "computed", computed)
 		fh.Close()
 		return nil, nil, fmt.Errorf("CRC mismatch")
 	}
 
 	// Seek to the start
 	if _, err := fh.Seek(0, 0); err != nil {
-		f.logger.Printf("[ERR] snapshot: State file seek failed: %v", err)
+		f.logger.Error("state file seek failed", "error", err)
 		fh.Close()
 		return nil, nil, err
 	}
@@ -349,15 +356,15 @@ func (f *FileSnapshotStore) Open(id string) (*SnapshotMeta, io.ReadCloser, error
 func (f *FileSnapshotStore) ReapSnapshots() error {
 	snapshots, err := f.getSnapshots()
 	if err != nil {
-		f.logger.Printf("[ERR] snapshot: Failed to get snapshots: %v", err)
+		f.logger.Error("failed to get snapshots", "error", err)
 		return err
 	}
 
 	for i := f.retain; i < len(snapshots); i++ {
 		path := filepath.Join(f.path, snapshots[i].ID)
-		f.logger.Printf("[INFO] snapshot: reaping snapshot %v", path)
+		f.logger.Info("reaping snapshot", "path", path)
 		if err := os.RemoveAll(path); err != nil {
-			f.logger.Printf("[ERR] snapshot: Failed to reap snapshot %v: %v", path, err)
+			f.logger.Error("failed to reap snapshot", "path", path, "error", err)
 			return err
 		}
 	}
@@ -386,9 +393,9 @@ func (s *FileSnapshotSink) Close() error {
 
 	// Close the open handles
 	if err := s.finalize(); err != nil {
-		s.logger.Printf("[ERR] snapshot: Failed to finalize snapshot: %v", err)
+		s.logger.Error("failed to finalize snapshot", "error", err)
 		if delErr := os.RemoveAll(s.dir); delErr != nil {
-			s.logger.Printf("[ERR] snapshot: Failed to delete temporary snapshot directory at path %v: %v", s.dir, delErr)
+			s.logger.Error("failed to delete temporary snapshot directory", "path", s.dir, "error", delErr)
 			return delErr
 		}
 		return err
@@ -396,27 +403,27 @@ func (s *FileSnapshotSink) Close() error {
 
 	// Write out the meta data
 	if err := s.writeMeta(); err != nil {
-		s.logger.Printf("[ERR] snapshot: Failed to write metadata: %v", err)
+		s.logger.Error("failed to write metadata", "error", err)
 		return err
 	}
 
 	// Move the directory into place
 	newPath := strings.TrimSuffix(s.dir, tmpSuffix)
 	if err := os.Rename(s.dir, newPath); err != nil {
-		s.logger.Printf("[ERR] snapshot: Failed to move snapshot into place: %v", err)
+		s.logger.Error("failed to move snapshot into place", "error", err)
 		return err
 	}
 
-	if runtime.GOOS != "windows" { //skipping fsync for directory entry edits on Windows, only needed for *nix style file systems
+	if runtime.GOOS != "windows" { // skipping fsync for directory entry edits on Windows, only needed for *nix style file systems
 		parentFH, err := os.Open(s.parentDir)
 		defer parentFH.Close()
 		if err != nil {
-			s.logger.Printf("[ERR] snapshot: Failed to open snapshot parent directory %v, error: %v", s.parentDir, err)
+			s.logger.Error("failed to open snapshot parent directory", "path", s.parentDir, "error", err)
 			return err
 		}
 
 		if err = parentFH.Sync(); err != nil {
-			s.logger.Printf("[ERR] snapshot: Failed syncing parent directory %v, error: %v", s.parentDir, err)
+			s.logger.Error("failed syncing parent directory", "path", s.parentDir, "error", err)
 			return err
 		}
 	}
@@ -439,7 +446,7 @@ func (s *FileSnapshotSink) Cancel() error {
 
 	// Close the open handles
 	if err := s.finalize(); err != nil {
-		s.logger.Printf("[ERR] snapshot: Failed to finalize snapshot: %v", err)
+		s.logger.Error("failed to finalize snapshot", "error", err)
 		return err
 	}
 

--- a/fuzzy/node.go
+++ b/fuzzy/node.go
@@ -2,7 +2,7 @@ package fuzzy
 
 import (
 	"fmt"
-	"log"
+	"github.com/hashicorp/go-hclog"
 	"path/filepath"
 	"time"
 
@@ -14,18 +14,18 @@ type raftNode struct {
 	transport *transport
 	store     *rdb.BoltStore
 	raft      *raft.Raft
-	log       *log.Logger
+	log       hclog.Logger
 	fsm       *fuzzyFSM
 	name      string
 	dir       string
 }
 
-func newRaftNode(logger *log.Logger, tc *transports, h TransportHooks, nodes []string, name string) (*raftNode, error) {
+func newRaftNode(logger hclog.Logger, tc *transports, h TransportHooks, nodes []string, name string) (*raftNode, error) {
 	datadir, err := resolveDirectory(fmt.Sprintf("data/%v", name), true)
 	if err != nil {
 		return nil, err
 	}
-	logger.Printf("[INFO] Creating new raft Node with data in dir %v", datadir)
+	logger.Info("creating new raft node with data in", "directory", datadir)
 	ss, err := raft.NewFileSnapshotStoreWithLogger(datadir, 5, logger)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to initialize snapshots %v\n", err.Error())

--- a/fuzzy/transport.go
+++ b/fuzzy/transport.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/go-hclog"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -32,10 +32,10 @@ type appendEntries struct {
 type transports struct {
 	sync.RWMutex
 	nodes map[string]*transport
-	log   *log.Logger
+	log   hclog.Logger
 }
 
-func newTransports(log *log.Logger) *transports {
+func newTransports(log hclog.Logger) *transports {
 	return &transports{
 		nodes: make(map[string]*transport),
 		log:   log,
@@ -65,7 +65,7 @@ type TransportHooks interface {
 }
 
 type transport struct {
-	log        *log.Logger
+	log        hclog.Logger
 	transports *transports
 	node       string
 	ae         []appendEntries
@@ -99,7 +99,7 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 	t.transports.RLock()
 	tt := t.transports.nodes[target]
 	if tt == nil {
-		t.log.Printf("sendRPC target=%v but unknown node (transports=%v)", target, t.transports.nodes)
+		t.log.Info("sendRPC unknown node", "target", target, "transports", t.transports.nodes)
 		t.transports.RUnlock()
 		return fmt.Errorf("Unknown target host %v", target)
 	}
@@ -132,7 +132,7 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 		}
 		rpc.Command = &appEnt
 	default:
-		t.log.Printf("Unexpected request type %T %+v", req, req)
+		t.log.Warn("unexpected request type", "type", fmt.Sprintf("%T", req), "request", req)
 	}
 	var result *raft.RPCResponse
 	if t.hooks != nil {
@@ -152,7 +152,7 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 			}
 		}
 	}
-	//t.log.Printf("sendRPC %v -> %v : %+v", t.node, target, rpc.Command)
+	// t.log.Printf("sendRPC %v -> %v : %+v", t.node, target, rpc.Command)
 	if result == nil {
 		tt.consumer <- rpc
 		cr := <-rc
@@ -165,7 +165,7 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 			result.Error = err
 		}
 	}
-	//t.log.Printf("sendRPC %v <- %v: %+v %v", t.node, target, result.Response, result.Error)
+	// t.log.Printf("sendRPC %v <- %v: %+v %v", t.node, target, result.Response, result.Error)
 	buff = bytes.Buffer{}
 	codec.NewEncoder(&buff, &codecHandle).Encode(result.Response)
 	codec.NewDecoderBytes(buff.Bytes(), &codecHandle).Decode(resp)
@@ -225,7 +225,7 @@ func (t *transport) RequestVote(id raft.ServerID, target raft.ServerAddress, arg
 // InstallSnapshot is used to push a snapshot down to a follower. The data is read from
 // the ReadCloser and streamed to the client.
 func (t *transport) InstallSnapshot(id raft.ServerID, target raft.ServerAddress, args *raft.InstallSnapshotRequest, resp *raft.InstallSnapshotResponse, data io.Reader) error {
-	t.log.Printf("INSTALL SNAPSHOT *************************************")
+	t.log.Debug("INSTALL SNAPSHOT *************************************")
 	return errors.New("huh")
 }
 

--- a/fuzzy/transport.go
+++ b/fuzzy/transport.go
@@ -152,7 +152,6 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 			}
 		}
 	}
-	// t.log.Printf("sendRPC %v -> %v : %+v", t.node, target, rpc.Command)
 	if result == nil {
 		tt.consumer <- rpc
 		cr := <-rc
@@ -165,7 +164,6 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 			result.Error = err
 		}
 	}
-	// t.log.Printf("sendRPC %v <- %v: %+v %v", t.node, target, result.Response, result.Error)
 	buff = bytes.Buffer{}
 	codec.NewEncoder(&buff, &codecHandle).Encode(result.Response)
 	codec.NewDecoderBytes(buff.Bytes(), &codecHandle).Decode(resp)

--- a/fuzzy/transport.go
+++ b/fuzzy/transport.go
@@ -132,7 +132,7 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 		}
 		rpc.Command = &appEnt
 	default:
-		t.log.Warn("unexpected request type", "type", fmt.Sprintf("%T", req), "request", req)
+		t.log.Warn("unexpected request type", "type", hclog.Fmt("%T", req), "request", req)
 	}
 	var result *raft.RPCResponse
 	if t.hooks != nil {

--- a/integ_test.go
+++ b/integ_test.go
@@ -58,7 +58,7 @@ func (r *RaftEnv) Restart(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	r.trans = trans
-	r.logger.Info(fmt.Sprintf("Starting node at %v", trans.LocalAddr()))
+	r.logger.Info("starting node", "addr", trans.LocalAddr())
 	raft, err := NewRaft(r.conf, r.fsm, r.store, r.store, r.snapshot, r.trans)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -113,7 +113,7 @@ func MakeRaft(t *testing.T, conf *Config, bootstrap bool) *RaftEnv {
 			t.Fatalf("err: %v", err)
 		}
 	}
-	env.logger.Info(fmt.Sprintf("Starting node at %v", trans.LocalAddr()))
+	env.logger.Info("starting node", "addr", trans.LocalAddr())
 	conf.Logger = env.logger
 	raft, err := NewRaft(conf, env.fsm, stable, stable, snap, trans)
 	if err != nil {
@@ -240,7 +240,7 @@ func TestRaft_Integ(t *testing.T) {
 		}
 		for _, f := range futures {
 			NoErr(WaitFuture(f, t), t)
-			leader.logger.Debug(fmt.Sprintf("Applied at %d, size %d", f.Index(), sz))
+			leader.logger.Debug("applied", "index", f.Index(), "size", sz)
 		}
 		totalApplied += n
 	}

--- a/net_transport.go
+++ b/net_transport.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/go-hclog"
 	"io"
-	"log"
 	"net"
 	"os"
 	"sync"
@@ -66,7 +66,7 @@ type NetworkTransport struct {
 	heartbeatFn     func(RPC)
 	heartbeatFnLock sync.Mutex
 
-	logger *log.Logger
+	logger hclog.Logger
 
 	maxPool int
 
@@ -92,7 +92,7 @@ type NetworkTransportConfig struct {
 	// ServerAddressProvider is used to override the target address when establishing a connection to invoke an RPC
 	ServerAddressProvider ServerAddressProvider
 
-	Logger *log.Logger
+	Logger hclog.Logger
 
 	// Dialer
 	Stream StreamLayer
@@ -148,7 +148,11 @@ func NewNetworkTransportWithConfig(
 	config *NetworkTransportConfig,
 ) *NetworkTransport {
 	if config.Logger == nil {
-		config.Logger = log.New(os.Stderr, "", log.LstdFlags)
+		config.Logger = hclog.New(&hclog.LoggerOptions{
+			Name:   "raft-net",
+			Output: hclog.DefaultOutput,
+			Level:  hclog.DefaultLevel,
+		})
 	}
 	trans := &NetworkTransport{
 		connPool:              make(map[ServerAddress][]*netConn),
@@ -182,7 +186,11 @@ func NewNetworkTransport(
 	if logOutput == nil {
 		logOutput = os.Stderr
 	}
-	logger := log.New(logOutput, "", log.LstdFlags)
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:   "raft-net",
+		Output: logOutput,
+		Level:  hclog.DefaultLevel,
+	})
 	config := &NetworkTransportConfig{Stream: stream, MaxPool: maxPool, Timeout: timeout, Logger: logger}
 	return NewNetworkTransportWithConfig(config)
 }
@@ -195,7 +203,7 @@ func NewNetworkTransportWithLogger(
 	stream StreamLayer,
 	maxPool int,
 	timeout time.Duration,
-	logger *log.Logger,
+	logger hclog.Logger,
 ) *NetworkTransport {
 	config := &NetworkTransportConfig{Stream: stream, MaxPool: maxPool, Timeout: timeout, Logger: logger}
 	return NewNetworkTransportWithConfig(config)
@@ -310,7 +318,7 @@ func (n *NetworkTransport) getProviderAddressOrFallback(id ServerID, target Serv
 	if n.serverAddressProvider != nil {
 		serverAddressOverride, err := n.serverAddressProvider.ServerAddr(id)
 		if err != nil {
-			n.logger.Printf("[WARN] raft: Unable to get address for server id %v, using fallback address %v: %v", id, target, err)
+			n.logger.Warn(fmt.Sprintf("unable to get address for server id %s, using fallback address %v", id, target), err)
 		} else {
 			return serverAddressOverride
 		}
@@ -486,7 +494,7 @@ func (n *NetworkTransport) listen() {
 			}
 
 			if !n.IsShutdown() {
-				n.logger.Printf("[ERR] raft-net: Failed to accept connection: %v", err)
+				n.logger.Error("failed to accept connection", "error", err)
 			}
 
 			select {
@@ -499,7 +507,7 @@ func (n *NetworkTransport) listen() {
 		// No error, reset loop delay
 		loopDelay = 0
 
-		n.logger.Printf("[DEBUG] raft-net: %v accepted connection from: %v", n.LocalAddr(), conn.RemoteAddr())
+		n.logger.Debug("accepted connection", "local-address", n.LocalAddr(), "remote-address", conn.RemoteAddr().String())
 
 		// Handle the connection in dedicated routine
 		go n.handleConn(n.getStreamContext(), conn)
@@ -519,19 +527,19 @@ func (n *NetworkTransport) handleConn(connCtx context.Context, conn net.Conn) {
 	for {
 		select {
 		case <-connCtx.Done():
-			n.logger.Println("[DEBUG] raft-net: stream layer is closed")
+			n.logger.Debug("stream layer is closed")
 			return
 		default:
 		}
 
 		if err := n.handleCommand(r, dec, enc); err != nil {
 			if err != io.EOF {
-				n.logger.Printf("[ERR] raft-net: Failed to decode incoming command: %v", err)
+				n.logger.Error("failed to decode incoming command", "error", err)
 			}
 			return
 		}
 		if err := w.Flush(); err != nil {
-			n.logger.Printf("[ERR] raft-net: Failed to flush response: %v", err)
+			n.logger.Error("failed to flush response", "error", err)
 			return
 		}
 	}

--- a/net_transport.go
+++ b/net_transport.go
@@ -318,7 +318,7 @@ func (n *NetworkTransport) getProviderAddressOrFallback(id ServerID, target Serv
 	if n.serverAddressProvider != nil {
 		serverAddressOverride, err := n.serverAddressProvider.ServerAddr(id)
 		if err != nil {
-			n.logger.Warn(fmt.Sprintf("unable to get address for server id %s, using fallback address %v", id, target), err)
+			n.logger.Warn("unable to get address for sever, using fallback address", "id", id, "fallback", target, "error", err)
 		} else {
 			return serverAddressOverride
 		}

--- a/replication.go
+++ b/replication.go
@@ -405,8 +405,8 @@ func (r *Raft) pipelineReplicate(s *followerReplication) error {
 	defer pipeline.Close()
 
 	// Log start and stop of pipeline
-	r.logger.Info(fmt.Sprintf("pipelining replication to peer %v", s.peer))
-	defer r.logger.Info(fmt.Sprintf("aborting pipeline replication to peer %v", s.peer))
+	r.logger.Info("pipelining replication", "peer", s.peer)
+	defer r.logger.Info("aborting pipeline replication", "peer", s.peer)
 
 	// Create a shutdown and finish channel
 	stopCh := make(chan struct{})
@@ -467,7 +467,7 @@ func (r *Raft) pipelineSend(s *followerReplication, p AppendPipeline, nextIdx *u
 
 	// Pipeline the append entries
 	if _, err := p.AppendEntries(req, new(AppendEntriesResponse)); err != nil {
-		r.logger.Error(fmt.Sprintf("Failed to pipeline AppendEntries to %v: %v", s.peer, err))
+		r.logger.Error("failed to pipeline appendEntries", "peer", s.peer, "error", err)
 		return true
 	}
 
@@ -543,7 +543,7 @@ func (r *Raft) setPreviousLog(req *AppendEntriesRequest, nextIndex uint64) error
 	} else {
 		var l Log
 		if err := r.logs.GetLog(nextIndex-1, &l); err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to get log at index %d: %v", nextIndex-1, err))
+			r.logger.Error("failed to get log", "index", nextIndex-1, "error", err)
 			return err
 		}
 
@@ -562,7 +562,7 @@ func (r *Raft) setNewLogs(req *AppendEntriesRequest, nextIndex, lastIndex uint64
 	for i := nextIndex; i <= maxIndex; i++ {
 		oldLog := new(Log)
 		if err := r.logs.GetLog(i, oldLog); err != nil {
-			r.logger.Error(fmt.Sprintf("Failed to get log at index %d: %v", i, err))
+			r.logger.Error("failed to get log", "index", i, "error", err)
 			return err
 		}
 		req.Entries = append(req.Entries, oldLog)
@@ -578,7 +578,7 @@ func appendStats(peer string, start time.Time, logs float32) {
 
 // handleStaleTerm is used when a follower indicates that we have a stale term.
 func (r *Raft) handleStaleTerm(s *followerReplication) {
-	r.logger.Error(fmt.Sprintf("peer %v has newer term, stopping replication", s.peer))
+	r.logger.Error("peer has newer term, stopping replication", "peer", s.peer)
 	s.notifyAll(false) // No longer leader
 	asyncNotifyCh(s.stepDown)
 }

--- a/snapshot.go
+++ b/snapshot.go
@@ -77,14 +77,14 @@ func (r *Raft) runSnapshots() {
 
 			// Trigger a snapshot
 			if _, err := r.takeSnapshot(); err != nil {
-				r.logger.Error(fmt.Sprintf("Failed to take snapshot: %v", err))
+				r.logger.Error("failed to take snapshot", "error", err)
 			}
 
 		case future := <-r.userSnapshotCh:
 			// User-triggered, run immediately
 			id, err := r.takeSnapshot()
 			if err != nil {
-				r.logger.Error(fmt.Sprintf("Failed to take snapshot: %v", err))
+				r.logger.Error("failed to take snapshot", "error", err)
 			} else {
 				future.opener = func() (*SnapshotMeta, io.ReadCloser, error) {
 					return r.snapshots.Open(id)
@@ -107,7 +107,7 @@ func (r *Raft) shouldSnapshot() bool {
 	// Check the last log index
 	lastIdx, err := r.logs.LastIndex()
 	if err != nil {
-		r.logger.Error(fmt.Sprintf("Failed to get last log index: %v", err))
+		r.logger.Error("failed to get last log index", "error", err)
 		return false
 	}
 
@@ -172,7 +172,7 @@ func (r *Raft) takeSnapshot() (string, error) {
 	}
 
 	// Create a new snapshot.
-	r.logger.Info(fmt.Sprintf("Starting snapshot up to %d", snapReq.index))
+	r.logger.Info("starting snapshot up to", "index", snapReq.index)
 	start := time.Now()
 	version := getSnapshotVersion(r.protocolVersion)
 	sink, err := r.snapshots.Create(version, snapReq.index, snapReq.term, committed, committedIndex, r.trans)
@@ -202,7 +202,7 @@ func (r *Raft) takeSnapshot() (string, error) {
 		return "", err
 	}
 
-	r.logger.Info(fmt.Sprintf("Snapshot to %d complete", snapReq.index))
+	r.logger.Info("snapshot complete up to", "index", snapReq.index)
 	return sink.ID(), nil
 }
 
@@ -228,8 +228,7 @@ func (r *Raft) compactLogs(snapIdx uint64) error {
 	// after the snapshot to be removed.
 	maxLog := min(snapIdx, lastLogIdx-r.conf.TrailingLogs)
 
-	// Log this
-	r.logger.Info(fmt.Sprintf("Compacting logs from %d to %d", minLog, maxLog))
+	r.logger.Info("compacting logs", "from", minLog, "to", maxLog)
 
 	// Compact the logs
 	if err := r.logs.DeleteRange(minLog, maxLog); err != nil {

--- a/tcp_transport.go
+++ b/tcp_transport.go
@@ -2,8 +2,8 @@ package raft
 
 import (
 	"errors"
+	"github.com/hashicorp/go-hclog"
 	"io"
-	"log"
 	"net"
 	"time"
 )
@@ -40,7 +40,7 @@ func NewTCPTransportWithLogger(
 	advertise net.Addr,
 	maxPool int,
 	timeout time.Duration,
-	logger *log.Logger,
+	logger hclog.Logger,
 ) (*NetworkTransport, error) {
 	return newTCPTransport(bindAddr, advertise, func(stream StreamLayer) *NetworkTransport {
 		return NewNetworkTransportWithLogger(stream, maxPool, timeout, logger)

--- a/testing.go
+++ b/testing.go
@@ -360,7 +360,6 @@ func (c *cluster) pollState(s RaftState) ([]*Raft, uint64) {
 // settled into the given state.
 func (c *cluster) GetInState(s RaftState) []*Raft {
 	c.logger.Info("starting stability test", "raft-state", s)
-	// c.logger.Printf("[INFO] Starting stability test for raft state: %+v", s)
 	limitCh := time.After(c.longstopTimeout)
 
 	// An election should complete after 2 * max(HeartbeatTimeout, ElectionTimeout)

--- a/testing.go
+++ b/testing.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"reflect"
 	"sync"
@@ -151,12 +150,18 @@ func (a *testLoggerAdapter) Write(d []byte) (int, error) {
 	return len(d), nil
 }
 
-func newTestLogger(t *testing.T) *log.Logger {
-	return log.New(&testLoggerAdapter{t: t}, "", log.Lmicroseconds)
+func newTestLogger(t *testing.T) hclog.Logger {
+	return hclog.New(&hclog.LoggerOptions{
+		Output: &testLoggerAdapter{t: t},
+		Level:  hclog.DefaultLevel,
+	})
 }
 
-func newTestLoggerWithPrefix(t *testing.T, prefix string) *log.Logger {
-	return log.New(&testLoggerAdapter{t: t, prefix: prefix}, "", log.Lmicroseconds)
+func newTestLoggerWithPrefix(t *testing.T, prefix string) hclog.Logger {
+	return hclog.New(&hclog.LoggerOptions{
+		Output: &testLoggerAdapter{t: t, prefix: prefix},
+		Level:  hclog.DefaultLevel,
+	})
 }
 
 func newTestLeveledLogger(t *testing.T) hclog.Logger {
@@ -185,7 +190,7 @@ type cluster struct {
 	conf             *Config
 	propagateTimeout time.Duration
 	longstopTimeout  time.Duration
-	logger           *log.Logger
+	logger           hclog.Logger
 	startTime        time.Time
 
 	failedLock sync.Mutex
@@ -222,7 +227,7 @@ func (c *cluster) notifyFailed() {
 // thread to block until all goroutines have completed in order to reliably
 // fail tests using this function.
 func (c *cluster) Failf(format string, args ...interface{}) {
-	c.logger.Printf(format, args...)
+	c.logger.Error(fmt.Sprintf(format, args...))
 	c.t.Fail()
 	c.notifyFailed()
 }
@@ -233,7 +238,7 @@ func (c *cluster) Failf(format string, args ...interface{}) {
 // other goroutines created during the test. Calling FailNowf does not stop
 // those other goroutines.
 func (c *cluster) FailNowf(format string, args ...interface{}) {
-	c.logger.Printf(format, args...)
+	c.logger.Error(fmt.Sprintf(format, args...))
 	c.t.FailNow()
 }
 
@@ -254,7 +259,7 @@ func (c *cluster) Close() {
 
 	for _, f := range futures {
 		if err := f.Error(); err != nil {
-			c.FailNowf("[ERR] shutdown future err: %v", err)
+			c.FailNowf("shutdown future err: %v", err)
 		}
 	}
 
@@ -316,7 +321,7 @@ CHECK:
 			c.t.FailNow()
 
 		case <-limitCh:
-			c.FailNowf("[ERR] Timeout waiting for replication")
+			c.FailNowf("timeout waiting for replication")
 
 		case <-ch:
 			for _, fsmRaw := range c.fsms {
@@ -354,7 +359,8 @@ func (c *cluster) pollState(s RaftState) ([]*Raft, uint64) {
 // GetInState polls the state of the cluster and attempts to identify when it has
 // settled into the given state.
 func (c *cluster) GetInState(s RaftState) []*Raft {
-	c.logger.Printf("[INFO] Starting stability test for raft state: %+v", s)
+	c.logger.Info("starting stability test", "raft-state", s)
+	// c.logger.Printf("[INFO] Starting stability test for raft state: %+v", s)
 	limitCh := time.After(c.longstopTimeout)
 
 	// An election should complete after 2 * max(HeartbeatTimeout, ElectionTimeout)
@@ -411,17 +417,18 @@ func (c *cluster) GetInState(s RaftState) []*Raft {
 			c.t.FailNow()
 
 		case <-limitCh:
-			c.FailNowf("[ERR] Timeout waiting for stable %s state", s)
+			c.FailNowf("timeout waiting for stable %s state", s)
 
 		case <-c.WaitEventChan(filter, 0):
-			c.logger.Printf("[DEBUG] Resetting stability timeout")
+			c.logger.Debug("resetting stability timeout")
 
 		case t, ok := <-timer.C:
 			if !ok {
-				c.FailNowf("[ERR] Timer channel errored")
+				c.FailNowf("timer channel errored")
 			}
-			c.logger.Printf("[INFO] Stable state for %s reached at %s (%d nodes), %s from start of poll, %s from cluster start. Timeout at %s, %s after stability",
-				s, inStateTime, len(inState), inStateTime.Sub(pollStartTime), inStateTime.Sub(c.startTime), t, t.Sub(inStateTime))
+
+			c.logger.Info(fmt.Sprintf("stable state for %s reached at %s (%d nodes), %s from start of poll, %s from cluster start. Timeout at %s, %s after stability",
+				s, inStateTime, len(inState), inStateTime.Sub(pollStartTime), inStateTime.Sub(c.startTime), t, t.Sub(inStateTime)))
 			return inState
 		}
 	}
@@ -431,7 +438,7 @@ func (c *cluster) GetInState(s RaftState) []*Raft {
 func (c *cluster) Leader() *Raft {
 	leaders := c.GetInState(Leader)
 	if len(leaders) != 1 {
-		c.FailNowf("[ERR] expected one leader: %v", leaders)
+		c.FailNowf("expected one leader: %v", leaders)
 	}
 	return leaders[0]
 }
@@ -442,14 +449,14 @@ func (c *cluster) Followers() []*Raft {
 	expFollowers := len(c.rafts) - 1
 	followers := c.GetInState(Follower)
 	if len(followers) != expFollowers {
-		c.FailNowf("[ERR] timeout waiting for %d followers (followers are %v)", expFollowers, followers)
+		c.FailNowf("timeout waiting for %d followers (followers are %v)", expFollowers, followers)
 	}
 	return followers
 }
 
 // FullyConnect connects all the transports together.
 func (c *cluster) FullyConnect() {
-	c.logger.Printf("[DEBUG] Fully Connecting")
+	c.logger.Debug("fully connecting")
 	for i, t1 := range c.trans {
 		for j, t2 := range c.trans {
 			if i != j {
@@ -462,7 +469,7 @@ func (c *cluster) FullyConnect() {
 
 // Disconnect disconnects all transports from the given address.
 func (c *cluster) Disconnect(a ServerAddress) {
-	c.logger.Printf("[DEBUG] Disconnecting %v", a)
+	c.logger.Debug("disconnecting", "address", a)
 	for _, t := range c.trans {
 		if t.LocalAddr() == a {
 			t.DisconnectAll()
@@ -475,7 +482,7 @@ func (c *cluster) Disconnect(a ServerAddress) {
 // Partition keeps the given list of addresses connected but isolates them
 // from the other members of the cluster.
 func (c *cluster) Partition(far []ServerAddress) {
-	c.logger.Printf("[DEBUG] Partitioning %v", far)
+	c.logger.Debug("partitioning", "addresses", far)
 
 	// Gather the set of nodes on the "near" side of the partition (we
 	// will call the supplied list of nodes the "far" side).
@@ -530,15 +537,15 @@ func (c *cluster) EnsureLeader(t *testing.T, expect ServerAddress) {
 				leader = "[none]"
 			}
 			if expect == "" {
-				c.logger.Printf("[ERR] Peer %s sees leader %v expected [none]", r, leader)
+				c.logger.Error("peer sees incorrect leader", "peer", r, "leader", leader, "expected-leader", "[none]")
 			} else {
-				c.logger.Printf("[ERR] Peer %s sees leader %v expected %v", r, leader, expect)
+				c.logger.Error("peer sees incorrect leader", "peer", r, "leader", leader, "expected-leader", expect)
 			}
 			fail = true
 		}
 	}
 	if fail {
-		c.FailNowf("[ERR] At least one peer has the wrong notion of leader")
+		c.FailNowf("at least one peer has the wrong notion of leader")
 	}
 }
 
@@ -559,7 +566,7 @@ CHECK:
 		if len(first.logs) != len(fsm.logs) {
 			fsm.Unlock()
 			if time.Now().After(limit) {
-				c.FailNowf("[ERR] FSM log length mismatch: %d %d",
+				c.FailNowf("FSM log length mismatch: %d %d",
 					len(first.logs), len(fsm.logs))
 			} else {
 				goto WAIT
@@ -570,7 +577,7 @@ CHECK:
 			if bytes.Compare(first.logs[idx], fsm.logs[idx]) != 0 {
 				fsm.Unlock()
 				if time.Now().After(limit) {
-					c.FailNowf("[ERR] FSM log mismatch at index %d", idx)
+					c.FailNowf("FSM log mismatch at index %d", idx)
 				} else {
 					goto WAIT
 				}
@@ -579,7 +586,7 @@ CHECK:
 		if len(first.configurations) != len(fsm.configurations) {
 			fsm.Unlock()
 			if time.Now().After(limit) {
-				c.FailNowf("[ERR] FSM configuration length mismatch: %d %d",
+				c.FailNowf("FSM configuration length mismatch: %d %d",
 					len(first.logs), len(fsm.logs))
 			} else {
 				goto WAIT
@@ -590,7 +597,7 @@ CHECK:
 			if !reflect.DeepEqual(first.configurations[idx], fsm.configurations[idx]) {
 				fsm.Unlock()
 				if time.Now().After(limit) {
-					c.FailNowf("[ERR] FSM configuration mismatch at index %d: %v, %v", idx, first.configurations[idx], fsm.configurations[idx])
+					c.FailNowf("FSM configuration mismatch at index %d: %v, %v", idx, first.configurations[idx], fsm.configurations[idx])
 				} else {
 					goto WAIT
 				}
@@ -613,7 +620,7 @@ WAIT:
 func (c *cluster) getConfiguration(r *Raft) Configuration {
 	future := r.GetConfiguration()
 	if err := future.Error(); err != nil {
-		c.FailNowf("[ERR] failed to get configuration: %v", err)
+		c.FailNowf("failed to get configuration: %v", err)
 		return Configuration{}
 	}
 
@@ -634,7 +641,7 @@ CHECK:
 		otherSet := c.getConfiguration(raft)
 		if !reflect.DeepEqual(peerSet, otherSet) {
 			if time.Now().After(limit) {
-				c.FailNowf("[ERR] peer mismatch: %+v %+v", peerSet, otherSet)
+				c.FailNowf("peer mismatch: %+v %+v", peerSet, otherSet)
 			} else {
 				goto WAIT
 			}
@@ -687,7 +694,7 @@ func makeCluster(t *testing.T, opts *MakeClusterOpts) *cluster {
 	for i := 0; i < opts.Peers; i++ {
 		dir, err := ioutil.TempDir("", "raft")
 		if err != nil {
-			c.FailNowf("[ERR] err: %v ", err)
+			c.FailNowf("err: %v", err)
 		}
 
 		store := NewInmemStore()
@@ -742,18 +749,18 @@ func makeCluster(t *testing.T, opts *MakeClusterOpts) *cluster {
 		if opts.Bootstrap {
 			err := BootstrapCluster(peerConf, logs, store, snap, trans, configuration)
 			if err != nil {
-				c.FailNowf("[ERR] BootstrapCluster failed: %v", err)
+				c.FailNowf("BootstrapCluster failed: %v", err)
 			}
 		}
 
 		raft, err := NewRaft(peerConf, c.fsms[i], logs, store, snap, trans)
 		if err != nil {
-			c.FailNowf("[ERR] NewRaft failed: %v", err)
+			c.FailNowf("NewRaft failed: %v", err)
 		}
 
 		raft.RegisterObserver(NewObserver(c.observationCh, false, nil))
 		if err != nil {
-			c.FailNowf("[ERR] RegisterObserver failed: %v", err)
+			c.FailNowf("RegisterObserver failed: %v", err)
 		}
 		c.rafts = append(c.rafts, raft)
 	}


### PR DESCRIPTION
This simply replaces the existing logging implementation with hclog to
make everything consistent throughout the library.