### PR TITLE
[lint] Fix minor linter warnings.

### DIFF
--- a/configuration_test.go
+++ b/configuration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-var sampleConfiguration Configuration = Configuration{
+var sampleConfiguration = Configuration{
 	Servers: []Server{
 		Server{
 			Suffrage: Nonvoter,

--- a/future.go
+++ b/future.go
@@ -183,14 +183,14 @@ type userSnapshotFuture struct {
 func (u *userSnapshotFuture) Open() (*SnapshotMeta, io.ReadCloser, error) {
 	if u.opener == nil {
 		return nil, nil, fmt.Errorf("no snapshot available")
-	} else {
-		// Invalidate the opener so it can't get called multiple times,
-		// which isn't generally safe.
-		defer func() {
-			u.opener = nil
-		}()
-		return u.opener()
 	}
+
+	// Invalidate the opener so it can't get called multiple times,
+	// which isn't generally safe.
+	defer func() {
+		u.opener = nil
+	}()
+	return u.opener()
 }
 
 // userRestoreFuture is used for waiting on a user-triggered restore of an

--- a/fuzzy/node.go
+++ b/fuzzy/node.go
@@ -2,9 +2,10 @@ package fuzzy
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-hclog"
 	"path/filepath"
 	"time"
+
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/raft"
 	rdb "github.com/hashicorp/raft-boltdb"
@@ -49,7 +50,7 @@ func newRaftNode(logger hclog.Logger, tc *transports, h TransportHooks, nodes []
 		for _, n := range nodes {
 			c = append(c, raft.Server{Suffrage: raft.Voter, ID: raft.ServerID(n), Address: raft.ServerAddress(n)})
 		}
-		configuration := raft.Configuration{c}
+		configuration := raft.Configuration{Servers: c}
 		if err := raft.BootstrapCluster(config, store, store, ss, transport, configuration); err != nil {
 			return nil, err
 		}

--- a/replication.go
+++ b/replication.go
@@ -100,7 +100,7 @@ func (s *followerReplication) notifyAll(leader bool) {
 	s.notifyLock.Unlock()
 
 	// Submit our votes
-	for v, _ := range n {
+	for v := range n {
 		v.vote(leader)
 	}
 }

--- a/testing.go
+++ b/testing.go
@@ -506,7 +506,7 @@ OUTER:
 				t.Disconnect(a)
 			}
 		} else {
-			for a, _ := range near {
+			for a := range near {
 				t.Disconnect(a)
 			}
 		}


### PR DESCRIPTION
This addresses all non-comment related lint warnings generated by `go lint` and `go vet`.