### PR TITLE
Fix fuzzy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 TEST_RESULTS_DIR?=/tmp/test-results
 
 test:
-	go test -timeout=60s -race .
+	go test $(TESTARGS) -timeout=60s -race .
 
 integ: test
-	INTEG_TESTS=yes go test -timeout=25s -run=Integ .
+	INTEG_TESTS=yes go test $(TESTARGS) -timeout=25s -run=Integ .
 
 ci.test-norace:
 	gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-test.xml -- -timeout=60s

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ci.integ: ci.test
 	INTEG_TESTS=yes gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-integ.xml -- -timeout=25s -run=Integ .
 
 fuzz:
-	go test -timeout=300s ./fuzzy
+	go test $(TESTARGS) -timeout=20m ./fuzzy
 
 deps:
 	go get -t -d -v ./...

--- a/fuzzy/apply_src.go
+++ b/fuzzy/apply_src.go
@@ -54,7 +54,7 @@ func (ca *clusterApplier) apply(t *testing.T, c *cluster, n uint) {
 		case <-ca.stopCh:
 			return
 		default:
-			ca.applied += c.ApplyN(t, time.Second, ca.src, n)
+			ca.applied += c.ApplyN(t, 5*time.Second, ca.src, n)
 		}
 	}
 }

--- a/fuzzy/cluster.go
+++ b/fuzzy/cluster.go
@@ -3,13 +3,14 @@ package fuzzy
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/go-hclog"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/raft"
 )
@@ -239,8 +240,10 @@ func (c *cluster) sendNApplies(leaderTimeout time.Duration, data [][]byte) []app
 	f := []applyFutureWithData{}
 
 	ldr := c.Leader(leaderTimeout)
-	for _, d := range data {
-		f = append(f, applyFutureWithData{future: ldr.raft.Apply(d, time.Second), data: d})
+	if ldr != nil {
+		for _, d := range data {
+			f = append(f, applyFutureWithData{future: ldr.raft.Apply(d, time.Second), data: d})
+		}
 	}
 	return f
 }


### PR DESCRIPTION
This PR does three things in the `fuzzy/` directory, but the main thing is in the method `sendNApplies` where if the `Leader()` method returns `nil` due to hitting the timeout, then `sendNApplies` simply returns an empty slice instead of trying triggering a nil pointer dereference. 

It also extends the leader timeout as I found that alone helped many of the tests to pass. 

In the Makefile, I added support for `TESTARGS` so you can invoke `make fuzz` and run only specific tests, or use other things like `-count` or such. I also extended the timeout, as I found running the `TestRaft_FuzzyLeadershipTransfer` test alone was taking ~140 seconds on my laptop. 

I believe this fixes https://github.com/hashicorp/raft/issues/352 , in such that the tests no longer panic

Test results from my 2016 laptop:

```
[raft][fix_fuzzy](4)$ make fuzz 
go test  -timeout=20m ./fuzzy
ok      github.com/hashicorp/raft/fuzzy 933.596s
```