### PR TITLE
Enable FSM batching through optionally implemented interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,23 @@ test:
 
 integ: test
 	INTEG_TESTS=yes go test -timeout=25s -run=Integ .
+	INTEG_TESTS=yes go test -timeout=25s -tags batchtest -run=Integ .
 
 ci.test-norace:
 	gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-test.xml -- -timeout=60s
+	gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-test.xml -- -timeout=60s -tags batchtest
 
 ci.test:
 	gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-test.xml -- -timeout=60s -race .
+	gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-test.xml -- -timeout=60s -race -tags batchtest .
 
 ci.integ: ci.test
 	INTEG_TESTS=yes gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-integ.xml -- -timeout=25s -run=Integ .
+	INTEG_TESTS=yes gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-integ.xml -- -timeout=25s -run=Integ -tags batchtest .
 
 fuzz:
 	go test -timeout=300s ./fuzzy
+	go test -timeout=300s -tags batchtest ./fuzzy
 
 deps:
 	go get -t -d -v ./...

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ ci.integ: ci.test
 	INTEG_TESTS=yes gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-integ.xml -- -timeout=25s -run=Integ -tags batchtest .
 
 fuzz:
-	go test $(TESTARGS) -timeout=300s ./fuzzy
-	go test $(TESTARGS) -timeout=300s -tags batchtest ./fuzzy
+	go test $(TESTARGS) -timeout=500s ./fuzzy
+	go test $(TESTARGS) -timeout=500s -tags batchtest ./fuzzy
 
 deps:
 	go get -t -d -v ./...

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TEST_RESULTS_DIR?=/tmp/test-results
 
 test:
 	go test -timeout=60s -race .
+	go test -timeout=60s -tags batchtest -race .
 
 integ: test
 	INTEG_TESTS=yes go test -timeout=25s -run=Integ .

--- a/api.go
+++ b/api.go
@@ -234,7 +234,7 @@ func BootstrapCluster(conf *Config, logs LogStore, stable StableStore,
 		entry.Data = encodePeers(configuration, trans)
 	} else {
 		entry.Type = LogConfiguration
-		entry.Data = encodeConfiguration(configuration)
+		entry.Data = EncodeConfiguration(configuration)
 	}
 	if err := logs.StoreLog(entry); err != nil {
 		return fmt.Errorf("failed to append configuration entry to log: %v", err)

--- a/api.go
+++ b/api.go
@@ -478,7 +478,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	// Create Raft struct.
 	r := &Raft{
 		protocolVersion:       protocolVersion,
-		applyCh:               make(chan *logFuture, conf.MaxAppendEntries),
+		applyCh:               make(chan *logFuture),
 		conf:                  *conf,
 		fsm:                   fsm,
 		fsmMutateCh:           make(chan interface{}, 128),

--- a/api.go
+++ b/api.go
@@ -478,7 +478,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	// Create Raft struct.
 	r := &Raft{
 		protocolVersion:       protocolVersion,
-		applyCh:               make(chan *logFuture),
+		applyCh:               make(chan *logFuture, conf.MaxAppendEntries),
 		conf:                  *conf,
 		fsm:                   fsm,
 		fsmMutateCh:           make(chan interface{}, 128),

--- a/configuration.go
+++ b/configuration.go
@@ -342,9 +342,9 @@ func decodePeers(buf []byte, trans Transport) Configuration {
 	}
 }
 
-// encodeConfiguration serializes a Configuration using MsgPack, or panics on
+// EncodeConfiguration serializes a Configuration using MsgPack, or panics on
 // errors.
-func encodeConfiguration(configuration Configuration) []byte {
+func EncodeConfiguration(configuration Configuration) []byte {
 	buf, err := encodeMsgPack(configuration)
 	if err != nil {
 		panic(fmt.Errorf("failed to encode configuration: %v", err))

--- a/configuration.go
+++ b/configuration.go
@@ -352,9 +352,9 @@ func encodeConfiguration(configuration Configuration) []byte {
 	return buf.Bytes()
 }
 
-// decodeConfiguration deserializes a Configuration using MsgPack, or panics on
+// DecodeConfiguration deserializes a Configuration using MsgPack, or panics on
 // errors.
-func decodeConfiguration(buf []byte) Configuration {
+func DecodeConfiguration(buf []byte) Configuration {
 	var configuration Configuration
 	if err := decodeMsgPack(buf, &configuration); err != nil {
 		panic(fmt.Errorf("failed to decode configuration: %v", err))

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -307,7 +307,7 @@ func TestConfiguration_encodeDecodePeers(t *testing.T) {
 }
 
 func TestConfiguration_encodeDecodeConfiguration(t *testing.T) {
-	decoded := DecodeConfiguration(encodeConfiguration(sampleConfiguration))
+	decoded := DecodeConfiguration(EncodeConfiguration(sampleConfiguration))
 	if !reflect.DeepEqual(sampleConfiguration, decoded) {
 		t.Fatalf("mismatch %v %v", sampleConfiguration, decoded)
 	}

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -307,7 +307,7 @@ func TestConfiguration_encodeDecodePeers(t *testing.T) {
 }
 
 func TestConfiguration_encodeDecodeConfiguration(t *testing.T) {
-	decoded := decodeConfiguration(encodeConfiguration(sampleConfiguration))
+	decoded := DecodeConfiguration(encodeConfiguration(sampleConfiguration))
 	if !reflect.DeepEqual(sampleConfiguration, decoded) {
 		t.Fatalf("mismatch %v %v", sampleConfiguration, decoded)
 	}

--- a/fsm.go
+++ b/fsm.go
@@ -152,12 +152,15 @@ func (r *Raft) runFSM() {
 
 		var i int
 		for _, req := range reqs {
+			var resp interface{}
+			// If the log was sent to the FSM, retrieve the response.
+			if shouldSend(req.log) {
+				resp = responses[i]
+				i++
+			}
+
 			if req.future != nil {
-				// If the log was sent to the FSM, retrieve the response.
-				if shouldSend(req.log) {
-					req.future.response = responses[i]
-					i++
-				}
+				req.future.response = resp
 				req.future.respond(nil)
 			}
 		}

--- a/fuzzy/fsm_batch.go
+++ b/fuzzy/fsm_batch.go
@@ -1,0 +1,17 @@
+// +build batchtest
+
+package fuzzy
+
+import "github.com/hashicorp/raft"
+
+// ApplyBatch enables fuzzyFSM to satisfy the BatchingFSM interface. This
+// function is gated by the batchtest build flag.
+func (f *fuzzyFSM) ApplyBatch(logs []*raft.Log) []interface{} {
+	ret := make([]interface{}, len(logs))
+
+	for _, l := range logs {
+		f.Apply(l)
+	}
+
+	return ret
+}

--- a/raft.go
+++ b/raft.go
@@ -633,7 +633,7 @@ func (r *Raft) leaderLoop() {
 			start := time.Now()
 			var groupReady []*list.Element
 			var groupFutures = make(map[uint64]*logFuture)
-			var lastInGroup uint64
+			var lastIdxInGroup uint64
 
 			// Pull all inflight logs that are committed off the queue.
 			for e := r.leaderState.inflight.Front(); e != nil; e = e.Next() {
@@ -648,12 +648,12 @@ func (r *Raft) leaderLoop() {
 				metrics.MeasureSince([]string{"raft", "commitTime"}, commitLog.dispatch)
 				groupReady = append(groupReady, e)
 				groupFutures[idx] = commitLog
-				lastInGroup = idx
+				lastIdxInGroup = idx
 			}
 
 			// Process the group
 			if len(groupReady) != 0 {
-				r.processLogs(lastInGroup, groupFutures)
+				r.processLogs(lastIdxInGroup, groupFutures)
 
 				for _, e := range groupReady {
 					r.leaderState.inflight.Remove(e)
@@ -1037,7 +1037,7 @@ func (r *Raft) appendConfigurationEntry(future *configurationChangeFuture) {
 	} else {
 		future.log = Log{
 			Type: LogConfiguration,
-			Data: encodeConfiguration(configuration),
+			Data: EncodeConfiguration(configuration),
 		}
 	}
 

--- a/raft.go
+++ b/raft.go
@@ -1095,36 +1095,9 @@ func (r *Raft) dispatchLogs(applyLogs []*logFuture) {
 // applied up to the given index limit.
 // This can be called from both leaders and followers.
 // Followers call this from AppendEntries, for n entries at a time, and always
-// pass future=nil.
-// Leaders call this once per inflight when entries are committed. They pass
-// the future from inflights.
-/*func (r *Raft) processLogs(index uint64, future *logFuture) {
-	// Reject logs we've applied already
-	lastApplied := r.getLastApplied()
-	if index <= lastApplied {
-		r.logger.Warn("skipping application of old log", "index", index)
-		return
-	}
-
-	// Apply all the preceding logs
-	for idx := r.getLastApplied() + 1; idx <= index; idx++ {
-		// Get the log, either from the future or from our log store
-		if future != nil && future.log.Index == idx {
-			r.processLog(&future.log, future)
-		} else {
-			l := new(Log)
-			if err := r.logs.GetLog(idx, l); err != nil {
-				r.logger.Error("failed to get log", "index", idx, "error", err)
-				panic(err)
-			}
-			r.processLog(l, nil)
-		}
-
-		// Update the lastApplied index and term
-		r.setLastApplied(idx)
-	}
-}*/
-
+// pass futures=nil.
+// Leaders call this when entries are committed. They pass the futures from any
+// inflight logs.
 func (r *Raft) processLogs(index uint64, futures map[uint64]*logFuture) {
 	// Reject logs we've applied already
 	lastApplied := r.getLastApplied()

--- a/raft.go
+++ b/raft.go
@@ -1148,7 +1148,7 @@ func (r *Raft) processLogsBatch(index uint64, futures map[uint64]*logFuture) {
 	batch := make([]*commitTuple, 0, r.conf.MaxAppendEntries)
 
 	// Apply all the preceding logs
-	for idx := r.getLastApplied() + 1; idx <= index; idx++ {
+	for idx := lastApplied + 1; idx <= index; idx++ {
 		var preparedLog *commitTuple
 		// Get the log, either from the future or from our log store
 		future, futureOk := futures[idx]
@@ -1464,7 +1464,7 @@ func (r *Raft) processConfigurationLogEntry(entry *Log) {
 	if entry.Type == LogConfiguration {
 		r.configurations.committed = r.configurations.latest
 		r.configurations.committedIndex = r.configurations.latestIndex
-		r.configurations.latest = decodeConfiguration(entry.Data)
+		r.configurations.latest = DecodeConfiguration(entry.Data)
 		r.configurations.latestIndex = entry.Index
 	} else if entry.Type == LogAddPeerDeprecated || entry.Type == LogRemovePeerDeprecated {
 		r.configurations.committed = r.configurations.latest
@@ -1620,7 +1620,7 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	var reqConfiguration Configuration
 	var reqConfigurationIndex uint64
 	if req.SnapshotVersion > 0 {
-		reqConfiguration = decodeConfiguration(req.Configuration)
+		reqConfiguration = DecodeConfiguration(req.Configuration)
 		reqConfigurationIndex = req.ConfigurationIndex
 	} else {
 		reqConfiguration = decodePeers(req.Peers, r.trans)

--- a/raft_batch_test.go
+++ b/raft_batch_test.go
@@ -1,0 +1,17 @@
+// +build batchtest
+
+package raft
+
+// NOTE: This is exposed for middleware testing purposes and is not a stable API
+func (m *MockFSM) ApplyBatch(logs []*Log) []interface{} {
+	m.Lock()
+	defer m.Unlock()
+
+	ret := make([]interface{}, len(logs))
+	for i, log := range logs {
+		m.logs = append(m.logs, log.Data)
+		ret[i] = len(m.logs)
+	}
+
+	return ret
+}

--- a/raft_batch_test.go
+++ b/raft_batch_test.go
@@ -2,6 +2,10 @@
 
 package raft
 
+func init() {
+	userSnapshotErrorsOnNoData = false
+}
+
 // NOTE: This is exposed for middleware testing purposes and is not a stable API
 func (m *MockFSM) ApplyBatch(logs []*Log) []interface{} {
 	m.Lock()

--- a/raft_batch_test.go
+++ b/raft_batch_test.go
@@ -9,8 +9,13 @@ func (m *MockFSM) ApplyBatch(logs []*Log) []interface{} {
 
 	ret := make([]interface{}, len(logs))
 	for i, log := range logs {
-		m.logs = append(m.logs, log.Data)
-		ret[i] = len(m.logs)
+		switch log.Type {
+		case LogCommand:
+			m.logs = append(m.logs, log.Data)
+			ret[i] = len(m.logs)
+		default:
+			ret[i] = nil
+		}
 	}
 
 	return ret

--- a/raft_test.go
+++ b/raft_test.go
@@ -1540,7 +1540,7 @@ func TestRaft_Barrier(t *testing.T) {
 	// Ensure all the logs are the same
 	c.EnsureSame(t)
 	if len(getMockFSM(c.fsms[0]).logs) != 100 {
-		c.FailNowf("Bad log length")
+		c.FailNowf(fmt.Sprintf("Bad log length: %d", len(getMockFSM(c.fsms[0]).logs)))
 	}
 }
 

--- a/raft_test.go
+++ b/raft_test.go
@@ -14,6 +14,10 @@ import (
 	"time"
 )
 
+var (
+	userSnapshotErrorsOnNoData = true
+)
+
 func TestRaft_StartStop(t *testing.T) {
 	c := MakeCluster(1, t, nil)
 	c.Close()
@@ -1157,8 +1161,10 @@ func TestRaft_UserSnapshot(t *testing.T) {
 
 	// With nothing committed, asking for a snapshot should return an error.
 	leader := c.Leader()
-	if err := leader.Snapshot().Error(); err != ErrNothingNewToSnapshot {
-		c.FailNowf("Request for Snapshot failed: %v", err)
+	if userSnapshotErrorsOnNoData {
+		if err := leader.Snapshot().Error(); err != ErrNothingNewToSnapshot {
+			c.FailNowf("Request for Snapshot failed: %v", err)
+		}
 	}
 
 	// Commit some things.

--- a/raft_test.go
+++ b/raft_test.go
@@ -14,10 +14,6 @@ import (
 	"time"
 )
 
-var (
-	userSnapshotErrorsOnNoData = true
-)
-
 func TestRaft_StartStop(t *testing.T) {
 	c := MakeCluster(1, t, nil)
 	c.Close()

--- a/replication.go
+++ b/replication.go
@@ -314,7 +314,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 		LastLogTerm:        meta.Term,
 		Peers:              meta.Peers,
 		Size:               meta.Size,
-		Configuration:      encodeConfiguration(meta.Configuration),
+		Configuration:      EncodeConfiguration(meta.Configuration),
 		ConfigurationIndex: meta.ConfigurationIndex,
 	}
 

--- a/testing.go
+++ b/testing.go
@@ -15,6 +15,10 @@ import (
 	"github.com/hashicorp/go-msgpack/codec"
 )
 
+var (
+	userSnapshotErrorsOnNoData = true
+)
+
 // Return configurations optimized for in-memory
 func inmemConfig(t *testing.T) *Config {
 	conf := DefaultConfig()

--- a/testing_batch.go
+++ b/testing_batch.go
@@ -6,6 +6,9 @@ func init() {
 	userSnapshotErrorsOnNoData = false
 }
 
+// ApplyBatch enables MockFSM to satisfy the BatchingFSM interface. This
+// function is gated by the batchtest build flag.
+//
 // NOTE: This is exposed for middleware testing purposes and is not a stable API
 func (m *MockFSM) ApplyBatch(logs []*Log) []interface{} {
 	m.Lock()


### PR DESCRIPTION
Currently this library operates under the assumption that the FSM apply will be much faster than the Log apply. Based on this assumption the library does Log apply batching but no FSM level batching. When using an in-memory FSM this isn't a problem, but when the FSM is doing additional work- such as persisting the data to disk- this causes high latencies. 

This PR introduces a new `BatchingFSM` interface which extends the `FSM` interface to add an `ApplyBatch([]*Log) []interface{}` function. This can optionally be implemented by clients to enable multiple logs to be applied to the FSM in batches. Up to `MaxAppendEntries` could be sent in a batch.

`ApplyBatch` is invoked once a batch of log entries has been committed and are ready to be applied to the FSM. `ApplyBatch` will take in an array of log entries. These log entries could be of a few types so clients should check the log type prior to attempting to decode the data attached.  Presently the `LogCommand` and `LogConfiguration` types will be sent.

The returned slice must be the same length as the input. The returned values will be made available in the `ApplyFuture` returned by raft.Apply method if that method was called on the same Raft node as the FSM.