### PR TITLE
Move peer id from metric name to labels in raft replication

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -326,7 +326,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 		s.failures++
 		return false, err
 	}
-	metrics.MeasureSince([]string{"raft", "replication", "installSnapshot", string(s.peer.ID)}, start)
+	metrics.MeasureSinceWithLabels([]string{"raft", "replication", "installSnapshot"}, start, []metrics.Label{{Name: "raft_peer_id", Value: string(s.peer.ID)}})
 
 	// Check for a newer term, stop running
 	if resp.Term > req.Term {
@@ -386,7 +386,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 		} else {
 			s.setLastContact()
 			failures = 0
-			metrics.MeasureSince([]string{"raft", "replication", "heartbeat", string(s.peer.ID)}, start)
+			metrics.MeasureSinceWithLabels([]string{"raft", "replication", "heartbeat"}, start, []metrics.Label{{Name: "raft_peer_id", Value: string(s.peer.ID)}})
 			s.notifyAll(resp.Success)
 		}
 	}
@@ -572,8 +572,9 @@ func (r *Raft) setNewLogs(req *AppendEntriesRequest, nextIndex, lastIndex uint64
 
 // appendStats is used to emit stats about an AppendEntries invocation.
 func appendStats(peer string, start time.Time, logs float32) {
-	metrics.MeasureSince([]string{"raft", "replication", "appendEntries", "rpc", peer}, start)
-	metrics.IncrCounter([]string{"raft", "replication", "appendEntries", "logs", peer}, logs)
+	labels := []metrics.Label{{Name: "raft_peer_id", Value: peer}}
+	metrics.MeasureSinceWithLabels([]string{"raft", "replication", "appendEntries", "rpc"}, start, labels)
+	metrics.IncrCounterWithLabels([]string{"raft", "replication", "appendEntries", "logs"}, logs, labels)
 }
 
 // handleStaleTerm is used when a follower indicates that we have a stale term.


### PR DESCRIPTION
Hi,

Current raft replication metrics names include the peer id of the follower to which replication is made. 

While the information is important, I feel having the id in the metric name is less than ideal as it makes the metric hard to track and graph over the lifecycle of a cluster.

See hashicorp/consul#4450 for an example where users have to work around this in order to use the metric.

This PR removes the ID from the metric name, and adds a `raft_peer_id` label containing that ID.

Example before: 
```
consul_raft_replication_heartbeat_77884991_4b4b_636a_46c3_e1521741ca26_count 1.099632e+06                              
consul_raft_replication_heartbeat_77884991_4b4b_636a_46c3_e1521741ca26_count 1.099632e+06                              
```
Example after:
```
consul_raft_replication_heartbeat_count{raft_peer_id="77884991_4b4b_636a_46c3_e1521741ca2"} 6 1.099632e+06                              
consul_raft_replication_heartbeat_count{raft_peer_id="77884991_4b4b_636a_46c3_e1521741ca26"} 1.099632e+06                              
```