### PR TITLE
Update gauge metrics to histogram samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # UNRELEASED
 
+CHANGES
+
+* Existing gauge metrics `raft.commitNumLogs` and `raft.leader.dispatchNumLogs`
+  have been updated to histogram samples. Gauge was not the correct metric type
+  for these values and was causing samples to be dropped. Metrics sinks should
+  be updated accordingly. 
+
 FEATURES
 
 * Improve FSM apply performance through batching. Implementing the `BatchingFSM` interface enables this new feature [[GH-364](https://github.com/hashicorp/raft/pull/364)]

--- a/raft.go
+++ b/raft.go
@@ -664,7 +664,7 @@ func (r *Raft) leaderLoop() {
 			metrics.MeasureSince([]string{"raft", "fsm", "enqueue"}, start)
 
 			// Count the number of logs enqueued
-			metrics.SetGauge([]string{"raft", "commitNumLogs"}, float32(len(groupReady)))
+			metrics.AddSample([]string{"raft", "commitNumLogs"}, float32(len(groupReady)))
 
 			if stepDown {
 				if r.conf.ShutdownOnRemove {
@@ -1060,7 +1060,7 @@ func (r *Raft) dispatchLogs(applyLogs []*logFuture) {
 
 	n := len(applyLogs)
 	logs := make([]*Log, n)
-	metrics.SetGauge([]string{"raft", "leader", "dispatchNumLogs"}, float32(n))
+	metrics.AddSample([]string{"raft", "leader", "dispatchNumLogs"}, float32(n))
 
 	for idx, applyLog := range applyLogs {
 		applyLog.dispatch = now


### PR DESCRIPTION
 Existing gauge metrics `raft.commitNumLogs` and `raft.leader.dispatchNumLogs` have been updated to histogram samples. Gauge was not the correct metric type for these values and was causing samples to be dropped. Metrics sinks should be updated accordingly. 