### PR TITLE
Increase timeout for fuzz tests to 20 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ ci.integ: ci.test
 	INTEG_TESTS=yes gotestsum --format=short-verbose --junitfile $(TEST_RESULTS_DIR)/gotestsum-report-integ.xml -- -timeout=25s -run=Integ -tags batchtest .
 
 fuzz:
-	go test $(TESTARGS) -timeout=500s ./fuzzy
-	go test $(TESTARGS) -timeout=500s -tags batchtest ./fuzzy
+	go test $(TESTARGS) -timeout=20m ./fuzzy
+	go test $(TESTARGS) -timeout=20m -tags batchtest ./fuzzy
 
 deps:
 	go get -t -d -v ./...


### PR DESCRIPTION
A recent pull request (https://github.com/hashicorp/raft/pull/364) reduced the fuzz test timeout to 500s from 20m, probably inadvertently. 

On my 2016 MacBook Pro, 500s (8.33... minutes) is not enough, but 20
minutes usually is.

```
[raft][master](4)$ make fuzz 
go test  -timeout=20m ./fuzzy
ok      github.com/hashicorp/raft/fuzzy 1109.561s
go test  -timeout=20m -tags batchtest ./fuzzy
ok      github.com/hashicorp/raft/fuzzy 1065.439s
```