### PR TITLE
Obtain Configuration before Raft Starts

### DIFF
--- a/api.go
+++ b/api.go
@@ -382,6 +382,23 @@ func RecoverCluster(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 	return nil
 }
 
+// GetConfiguration returns the configuration of the Raft cluster without
+// starting a Raft instance or connecting to the cluster
+// This function has identical behavior to Raft.GetConfiguration
+func GetConfiguration(conf *Config, fsm FSM, logs LogStore, stable StableStore,
+	snaps SnapshotStore, trans Transport) (Configuration, error) {
+	conf.noBackgroundWork = true
+	r, err := NewRaft(conf, fsm, logs, stable, snaps, trans)
+	if err != nil {
+		return Configuration{}, err
+	}
+	future := r.GetConfiguration()
+	if err = future.Error(); err != nil {
+		return Configuration{}, err
+	}
+	return future.Configuration(), nil
+}
+
 // HasExistingState returns true if the server has any existing state (logs,
 // knowledge of a current term, or any snapshots).
 func HasExistingState(logs LogStore, stable StableStore, snaps SnapshotStore) (bool, error) {
@@ -542,10 +559,12 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	// to be called concurrently with a blocking RPC.
 	trans.SetHeartbeatHandler(r.processHeartbeat)
 
-	// Start the background work.
-	r.goFunc(r.run)
-	r.goFunc(r.runFSM)
-	r.goFunc(r.runSnapshots)
+	if !conf.noBackgroundWork {
+		// Start the background work.
+		r.goFunc(r.run)
+		r.goFunc(r.runFSM)
+		r.goFunc(r.runSnapshots)
+	}
 	return r, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -210,6 +210,9 @@ type Config struct {
 	// raft's configuration and index values. This is used in NewRaft and
 	// RestoreCluster.
 	NoSnapshotRestoreOnStart bool
+
+	// noBackgroundWork allows NewRaft() to bypass all background work goroutines
+	noBackgroundWork bool
 }
 
 // DefaultConfig returns a Config with usable defaults.

--- a/config.go
+++ b/config.go
@@ -211,8 +211,8 @@ type Config struct {
 	// RestoreCluster.
 	NoSnapshotRestoreOnStart bool
 
-	// noBackgroundWork allows NewRaft() to bypass all background work goroutines
-	noBackgroundWork bool
+	// skipStartup allows NewRaft() to bypass all background work goroutines
+	skipStartup bool
 }
 
 // DefaultConfig returns a Config with usable defaults.

--- a/raft_test.go
+++ b/raft_test.go
@@ -2124,6 +2124,42 @@ func TestRaft_LeadershipTransferStopRightAway(t *testing.T) {
 		t.Errorf("leadership shouldn't have started, but instead it error with: %v", err)
 	}
 }
+func TestRaft_GetConfigurationNoBootstrap(t *testing.T) {
+	c := MakeCluster(2, t, nil)
+	defer c.Close()
+
+	// Should be one leader
+	c.Followers()
+	leader := c.Leader()
+	c.EnsureLeader(t, leader.localAddr)
+
+	// Should be able to apply
+	future := leader.Apply([]byte("test"), c.conf.CommitTimeout)
+	if err := future.Error(); err != nil {
+		c.FailNowf("[ERR] err: %v", err)
+	}
+	c.WaitForReplication(1)
+
+	// Get configuration via GetConfiguration of a running node
+	cfgf := c.rafts[0].GetConfiguration()
+	if err := cfgf.Error(); err != nil {
+		t.Fatal(err)
+	}
+	expected := cfgf.Configuration()
+
+	// Obtain the same configuration via GetConfig
+	logs := c.stores[0]
+	store := c.stores[0]
+	snap := c.snaps[0]
+	trans := c.trans[0]
+	observed, err := GetConfiguration(c.conf, c.fsms[0], logs, store, snap, trans)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(observed, expected) {
+		t.Errorf("GetConfiguration result differ from Raft.GetConfiguration: observed %+v, expected %+v", observed, expected)
+	}
+}
 
 // TODO: These are test cases we'd like to write for appendEntries().
 // Unfortunately, it's difficult to do so with the current way this file is


### PR DESCRIPTION
Fixes #298. 
Introduces a new function `GetConfiguration` which allows for bypassing of background goroutines so the configuration can be obtained before Raft starts. 

Thanks @stapelberg  for help. Your PR laid the groundwork for this, and your test code was directly used. Thank you to @RobbieMcKinstry  for the direct guidance.

We took a different approach to implementation leaning on the existing `Raft.GetConfiguration()` future. @banks suggested using the `RecoverCluster` method, however we abandoned this idea due to the complexities of the signature. 
