### PR TITLE
Read latest configuration independently from main loop

### DIFF
--- a/api.go
+++ b/api.go
@@ -136,7 +136,10 @@ type Raft struct {
 
 	// Tracks the latest configuration and latest committed configuration from
 	// the log/snapshot.
-	configurations          configurations
+	configurations configurations
+
+	// Holds a copy of the latest configuration which can be read
+	// independently from main loop.
 	latestConfiguration     Configuration
 	latestConfigurationLock sync.RWMutex
 
@@ -747,9 +750,8 @@ func (r *Raft) VerifyLeader() Future {
 	}
 }
 
-// GetConfiguration returns the latest configuration and its associated index
-// currently in use. This may not yet be committed. This must not be called on
-// the main thread (which can access the information directly).
+// GetConfiguration returns the latest configuration. This may not yet be
+// committed. The main loop can access this directly.
 func (r *Raft) GetConfiguration() ConfigurationFuture {
 	configReq := &configurationsFuture{}
 	configReq.init()

--- a/api.go
+++ b/api.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
@@ -140,8 +141,7 @@ type Raft struct {
 
 	// Holds a copy of the latest configuration which can be read
 	// independently from main loop.
-	latestConfiguration     Configuration
-	latestConfigurationLock sync.RWMutex
+	latestConfiguration atomic.Value
 
 	// RPC chan comes from the transport layer
 	rpcCh <-chan RPC

--- a/raft.go
+++ b/raft.go
@@ -623,8 +623,7 @@ func (r *Raft) leaderLoop() {
 			// value.
 			if r.configurations.latestIndex > oldCommitIndex &&
 				r.configurations.latestIndex <= commitIndex {
-				r.configurations.committed = r.configurations.latest
-				r.configurations.committedIndex = r.configurations.latestIndex
+				r.setCommittedConfiguration(r.configurations.latest, r.configurations.latestIndex)
 				if !hasVote(r.configurations.committed, r.localID) {
 					stepDown = true
 				}
@@ -1043,8 +1042,7 @@ func (r *Raft) appendConfigurationEntry(future *configurationChangeFuture) {
 
 	r.dispatchLogs([]*logFuture{&future.logFuture})
 	index := future.Index()
-	r.configurations.latest = configuration
-	r.configurations.latestIndex = index
+	r.setLatestConfiguration(configuration, index)
 	r.leaderState.commitment.setConfiguration(configuration)
 	r.startStopReplication()
 }
@@ -1329,8 +1327,7 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 					return
 				}
 				if entry.Index <= r.configurations.latestIndex {
-					r.configurations.latest = r.configurations.committed
-					r.configurations.latestIndex = r.configurations.committedIndex
+					r.setLatestConfiguration(r.configurations.committed, r.configurations.committedIndex)
 				}
 				newEntries = a.Entries[i:]
 				break
@@ -1365,8 +1362,7 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 		idx := min(a.LeaderCommitIndex, r.getLastIndex())
 		r.setCommitIndex(idx)
 		if r.configurations.latestIndex <= idx {
-			r.configurations.committed = r.configurations.latest
-			r.configurations.committedIndex = r.configurations.latestIndex
+			r.setCommittedConfiguration(r.configurations.latest, r.configurations.latestIndex)
 		}
 		r.processLogs(idx, nil)
 		metrics.MeasureSince([]string{"raft", "rpc", "appendEntries", "processLogs"}, start)
@@ -1383,15 +1379,11 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 // called from the main thread, or from NewRaft() before any threads have begun.
 func (r *Raft) processConfigurationLogEntry(entry *Log) {
 	if entry.Type == LogConfiguration {
-		r.configurations.committed = r.configurations.latest
-		r.configurations.committedIndex = r.configurations.latestIndex
-		r.configurations.latest = DecodeConfiguration(entry.Data)
-		r.configurations.latestIndex = entry.Index
+		r.setCommittedConfiguration(r.configurations.latest, r.configurations.latestIndex)
+		r.setLatestConfiguration(DecodeConfiguration(entry.Data), entry.Index)
 	} else if entry.Type == LogAddPeerDeprecated || entry.Type == LogRemovePeerDeprecated {
-		r.configurations.committed = r.configurations.latest
-		r.configurations.committedIndex = r.configurations.latestIndex
-		r.configurations.latest = decodePeers(entry.Data, r.trans)
-		r.configurations.latestIndex = entry.Index
+		r.setCommittedConfiguration(r.configurations.latest, r.configurations.latestIndex)
+		r.setLatestConfiguration(decodePeers(entry.Data, r.trans), entry.Index)
 	}
 }
 
@@ -1606,10 +1598,8 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	r.setLastSnapshot(req.LastLogIndex, req.LastLogTerm)
 
 	// Restore the peer set
-	r.configurations.latest = reqConfiguration
-	r.configurations.latestIndex = reqConfigurationIndex
-	r.configurations.committed = reqConfiguration
-	r.configurations.committedIndex = reqConfigurationIndex
+	r.setLatestConfiguration(reqConfiguration, reqConfigurationIndex)
+	r.setCommittedConfiguration(reqConfiguration, reqConfigurationIndex)
 
 	// Compact logs, continue even if this fails
 	if err := r.compactLogs(req.LastLogIndex); err != nil {
@@ -1620,6 +1610,19 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	resp.Success = true
 	r.setLastContact()
 	return
+}
+
+func (r *Raft) setLatestConfiguration(c Configuration, i uint64) {
+	r.configurations.latest = c
+	r.configurations.latestIndex = i
+	r.latestConfigurationLock.Lock()
+	r.latestConfiguration = c.Clone()
+	r.latestConfigurationLock.Unlock()
+}
+
+func (r *Raft) setCommittedConfiguration(c Configuration, i uint64) {
+	r.configurations.committed = c
+	r.configurations.committedIndex = i
 }
 
 // setLastContact is used to set the last contact time to now
@@ -1795,4 +1798,10 @@ func (r *Raft) timeoutNow(rpc RPC, req *TimeoutNowRequest) {
 	r.setState(Candidate)
 	r.candidateFromLeadershipTransfer = true
 	rpc.Respond(&TimeoutNowResponse{}, nil)
+}
+
+func (r *Raft) getLatestConfiguration() Configuration {
+	r.latestConfigurationLock.RLock()
+	defer r.latestConfigurationLock.RUnlock()
+	return r.latestConfiguration.Clone()
 }

--- a/raft.go
+++ b/raft.go
@@ -1612,19 +1612,6 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	return
 }
 
-func (r *Raft) setLatestConfiguration(c Configuration, i uint64) {
-	r.configurations.latest = c
-	r.configurations.latestIndex = i
-	r.latestConfigurationLock.Lock()
-	r.latestConfiguration = c.Clone()
-	r.latestConfigurationLock.Unlock()
-}
-
-func (r *Raft) setCommittedConfiguration(c Configuration, i uint64) {
-	r.configurations.committed = c
-	r.configurations.committedIndex = i
-}
-
 // setLastContact is used to set the last contact time to now
 func (r *Raft) setLastContact() {
 	r.lastContactLock.Lock()
@@ -1800,6 +1787,24 @@ func (r *Raft) timeoutNow(rpc RPC, req *TimeoutNowRequest) {
 	rpc.Respond(&TimeoutNowResponse{}, nil)
 }
 
+// setLatestConfiguration stores the latest configuration and updates a copy of it.
+func (r *Raft) setLatestConfiguration(c Configuration, i uint64) {
+	r.configurations.latest = c
+	r.configurations.latestIndex = i
+	r.latestConfigurationLock.Lock()
+	r.latestConfiguration = c.Clone()
+	r.latestConfigurationLock.Unlock()
+}
+
+// setCommittedConfiguration stores the committed configuration.
+func (r *Raft) setCommittedConfiguration(c Configuration, i uint64) {
+	r.configurations.committed = c
+	r.configurations.committedIndex = i
+}
+
+// getLatestConfiguration reads the configuration from a copy of the main
+// configuration, which means it can be accessed independently from the main
+// loop.
 func (r *Raft) getLatestConfiguration() Configuration {
 	r.latestConfigurationLock.RLock()
 	defer r.latestConfigurationLock.RUnlock()


### PR DESCRIPTION
Before reading the raft configuration required the main loop to work off the `configurationsCh`. This is problematic in different scenarios:

* node is under high load
* leadership is flapping

The main reason why that was the case is that the `configurations` attribute must not be accessed in parallel which was guaranteed because it was only ever read or written from the `leaderLoop`.

By adding a copy of the latest configuration (which is ultimately what was returned) and protecting it with its own mutex, it is now possible to access the latest configuration from outside of the leader loop.

Fixes #302, #356, and improves https://github.com/hashicorp/consul/issues/6852.