### PR TITLE
Revert #370 "Improve error handling - remove hardcoded values"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,3 @@ _testmain.go
 
 *.exe
 *.test
-
-# MacOS
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# IDE specific
-.vscode/*

--- a/api.go
+++ b/api.go
@@ -52,7 +52,7 @@ var (
 	ErrEnqueueTimeout = errors.New("timed out enqueuing operation")
 
 	// ErrNothingNewToSnapshot is returned when trying to create a snapshot
-	// but there's nothing new committed to the FSM since we started.
+	// but there's nothing new commited to the FSM since we started.
 	ErrNothingNewToSnapshot = errors.New("nothing new to snapshot")
 
 	// ErrUnsupportedProtocol is returned when an operation is attempted
@@ -412,7 +412,7 @@ func HasExistingState(logs LogStore, stable StableStore, snaps SnapshotStore) (b
 			return true, nil
 		}
 	} else {
-		if err != ErrKeyNotFound {
+		if err.Error() != "not found" {
 			return false, fmt.Errorf("failed to read current term: %v", err)
 		}
 	}
@@ -466,7 +466,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 
 	// Try to restore the current term.
 	currentTerm, err := stable.GetUint64(keyCurrentTerm)
-	if err != nil && err != ErrKeyNotFound {
+	if err != nil && err.Error() != "not found" {
 		return nil, fmt.Errorf("failed to load current term: %v", err)
 	}
 
@@ -705,7 +705,7 @@ func (r *Raft) ApplyLog(log Log, timeout time.Duration) ApplyFuture {
 	}
 }
 
-// Barrier is used to issue a command that blocks until all preceding
+// Barrier is used to issue a command that blocks until all preceeding
 // operations have been applied to the FSM. It can be used to ensure the
 // FSM reflects all queued writes. An optional timeout can be provided to
 // limit the amount of time we wait for the command to be started. This

--- a/inmem_store.go
+++ b/inmem_store.go
@@ -5,11 +5,6 @@ import (
 	"sync"
 )
 
-var (
-	// ErrKeyNotFound is returned when a key does not exist in collection.
-	ErrKeyNotFound = errors.New("not found")
-)
-
 // InmemStore implements the LogStore and StableStore interface.
 // It should NOT EVER be used for production. It is used only for
 // unit tests. Use the MDBStore implementation instead.
@@ -114,7 +109,7 @@ func (i *InmemStore) Get(key []byte) ([]byte, error) {
 	defer i.l.RUnlock()
 	val := i.kv[string(key)]
 	if val == nil {
-		return nil, ErrKeyNotFound
+		return nil, errors.New("not found")
 	}
 	return val, nil
 }

--- a/raft.go
+++ b/raft.go
@@ -256,7 +256,7 @@ func (r *Raft) runCandidate() {
 	// Make sure the leadership transfer flag is reset after each run. Having this
 	// flag will set the field LeadershipTransfer in a RequestVoteRequst to true,
 	// which will make other servers vote even though they have a leader already.
-	// It is important to reset that flag, because this privilege could be abused
+	// It is important to reset that flag, because this priviledge could be abused
 	// otherwise.
 	defer func() { r.candidateFromLeadershipTransfer = false }()
 
@@ -1437,12 +1437,12 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 
 	// Check if we have voted yet
 	lastVoteTerm, err := r.stable.GetUint64(keyLastVoteTerm)
-	if err != nil && err != ErrKeyNotFound {
+	if err != nil && err.Error() != "not found" {
 		r.logger.Error("failed to get last vote term", "error", err)
 		return
 	}
 	lastVoteCandBytes, err := r.stable.Get(keyLastVoteCand)
-	if err != nil && err != ErrKeyNotFound {
+	if err != nil && err.Error() != "not found" {
 		r.logger.Error("failed to get last vote candidate", "error", err)
 		return
 	}


### PR DESCRIPTION
Reverts hashicorp/raft#370 , which inadvertently caused issues for other stores that don't implement and return `ErrKeyNotFound` error. 

Going forward, I believe this is still a good idea, but more needs to be offered through a common errors package of sorts, and likely too we should use a helper method that checks the type and message too, to offer backwards compatibility. That should be easy enough, but we're reverting for now. 