### PR TITLE
Set GOMAXPROCS=2 for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ references:
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: &TEST_RESULTS_DIR /tmp/test-results # path to where test results are saved
     GO111MODULE: 'on'
+    GOMAXPROCS: 2
 
 jobs:
   go-fmt-and-vet:


### PR DESCRIPTION
The CircleCI tests run in a Medium container (2CPUx4GB RAM). This will trim down the number of tests that can run in parallel (`-parallel` uses `GOMAXPROCS`) and hopefully make them more reliable. 