### PR TITLE
Fix TestRaft_StartAsLeader

### DIFF
--- a/api.go
+++ b/api.go
@@ -505,13 +505,6 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	// Initialize as a follower.
 	r.setState(Follower)
 
-	// Start as leader if specified. This should only be used
-	// for testing purposes.
-	if conf.StartAsLeader {
-		r.setState(Leader)
-		r.setLeader(r.localAddr)
-	}
-
 	// Restore the current term and the last log.
 	r.setCurrentTerm(currentTerm)
 	r.setLastLog(lastLog.Index, lastLog.Term)

--- a/config.go
+++ b/config.go
@@ -178,10 +178,6 @@ type Config struct {
 	// step down as leader.
 	LeaderLeaseTimeout time.Duration
 
-	// StartAsLeader forces Raft to start in the leader state. This should
-	// never be used except for testing purposes, as it can cause a split-brain.
-	StartAsLeader bool
-
 	// The unique ID for this server across all time. When running with
 	// ProtocolVersion < 3, you must set this to be the same as the network
 	// address of your transport.


### PR DESCRIPTION
`TestRaft_StartAsLeader` and `TestRaft_SingleNode` are similar however a key difference is StartAsLeader uses the "StartAsLeader" configuration flag which through testing we are finding is causing multiple failures. 
We will continue to dig in to see if this configuration flag is necessary, and if not we can "fix" this test by removing the flag. 