### PR TITLE
futures can react to shutdown

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -146,6 +146,7 @@ func (r *Raft) takeSnapshot() (string, error) {
 	// We have to use the future here to safely get this information since
 	// it is owned by the main thread.
 	configReq := &configurationsFuture{}
+	configReq.ShutdownCh = r.shutdownCh
 	configReq.init()
 	select {
 	case r.configurationsCh <- configReq:


### PR DESCRIPTION
This is implementing a very similar thing to https://github.com/hashicorp/raft/pull/277 but a little bit more generalized, like suggested by @mkeeler.

Fixes #277, fixes #268.