### PR TITLE
fix TestRaft_LeadershipTransferLeaderRejectsClientRequests test

### DIFF
--- a/raft_test.go
+++ b/raft_test.go
@@ -2027,7 +2027,6 @@ func TestRaft_LeadershipTransferLeaderRejectsClientRequests(t *testing.T) {
 		l.Apply([]byte("test"), 0),
 		l.Barrier(0),
 		l.DemoteVoter(ServerID(""), 0, 0),
-		l.GetConfiguration(),
 
 		// the API is tested, but here we are making sure we reject any config change.
 		l.requestConfigChange(configurationChangeRequest{}, 100*time.Millisecond),


### PR DESCRIPTION
TestRaft_LeadershipTransferLeaderRejectsClientRequests was failing because `GetConfiguration` is no longer dependent on the mainloop and can be retrieved even while leadership transfer!

TestRaft_LeaderLeaseExpire is now passing because I changed the code to wait for the leader to step down. Maybe the recent leaderch changes changes something. 🤷‍♂ 