### PR TITLE
deflake more tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,8 @@ version: 2.1
 
 references:
   images:
-    go-1.11: &GOLANG_1_11_IMAGE circleci/golang:1.11
-    go-1.12: &GOLANG_1_12_IMAGE circleci/golang:1.12
     go-1.13: &GOLANG_1_13_IMAGE circleci/golang:1.13
+    go-1.14: &GOLANG_1_14_IMAGE circleci/golang:1.14
 
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: &TEST_RESULTS_DIR /tmp/test-results # path to where test results are saved
@@ -15,7 +14,7 @@ references:
 jobs:
   go-fmt-and-vet:
     docker:
-      - image: *GOLANG_1_12_IMAGE
+      - image: *GOLANG_1_14_IMAGE
     steps:
       - checkout
 
@@ -102,28 +101,13 @@ workflows:
     jobs:
       - go-fmt-and-vet
       - go-test:
-          name: test go1.11
-          go-version: *GOLANG_1_11_IMAGE
-          requires:
-            - go-fmt-and-vet
-      - go-test:
-          name: test go1.12
-          go-version: *GOLANG_1_12_IMAGE
-          requires:
-            - go-fmt-and-vet
-      - go-test:
           name: test go1.13
           go-version: *GOLANG_1_13_IMAGE
           requires:
             - go-fmt-and-vet
-      - go-test-32bit:
-          name: test go1.11 - 32bit
-          go-version: *GOLANG_1_11_IMAGE
-          requires:
-            - go-fmt-and-vet
-      - go-test-32bit:
-          name: test go1.12 - 32 bit
-          go-version: *GOLANG_1_12_IMAGE
+      - go-test:
+          name: test go1.14
+          go-version: *GOLANG_1_14_IMAGE
           requires:
             - go-fmt-and-vet
       - go-test-32bit:
@@ -131,4 +115,10 @@ workflows:
           go-version: *GOLANG_1_13_IMAGE
           requires:
             - go-fmt-and-vet
+      - go-test-32bit:
+          name: test go1.14 - 32bit
+          go-version: *GOLANG_1_14_IMAGE
+          requires:
+            - go-fmt-and-vet
+
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ references:
   images:
     go-1.11: &GOLANG_1_11_IMAGE circleci/golang:1.11
     go-1.12: &GOLANG_1_12_IMAGE circleci/golang:1.12
+    go-1.13: &GOLANG_1_13_IMAGE circleci/golang:1.13
 
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: &TEST_RESULTS_DIR /tmp/test-results # path to where test results are saved
@@ -110,6 +111,11 @@ workflows:
           go-version: *GOLANG_1_12_IMAGE
           requires:
             - go-fmt-and-vet
+      - go-test:
+          name: test go1.13
+          go-version: *GOLANG_1_13_IMAGE
+          requires:
+            - go-fmt-and-vet
       - go-test-32bit:
           name: test go1.11 - 32bit
           go-version: *GOLANG_1_11_IMAGE
@@ -118,6 +124,11 @@ workflows:
       - go-test-32bit:
           name: test go1.12 - 32 bit
           go-version: *GOLANG_1_12_IMAGE
+          requires:
+            - go-fmt-and-vet
+      - go-test-32bit:
+          name: test go1.13 - 32bit
+          go-version: *GOLANG_1_13_IMAGE
           requires:
             - go-fmt-and-vet
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ references:
 
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: &TEST_RESULTS_DIR /tmp/test-results # path to where test results are saved
+    GOTRACEBACK: 'all'
     GO111MODULE: 'on'
     GOMAXPROCS: 2
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ endif
 TEST_RESULTS_DIR?=/tmp/test-results
 
 test:
-	go test $(TESTARGS) -timeout=60s -race .
-	go test $(TESTARGS) -timeout=60s -tags batchtest -race .
+	GOTRACEBACK=all go test $(TESTARGS) -timeout=60s -race .
+	GOTRACEBACK=all go test $(TESTARGS) -timeout=60s -tags batchtest -race .
 
 integ: test
 	INTEG_TESTS=yes go test $(TESTARGS) -timeout=25s -run=Integ .

--- a/inmem_transport.go
+++ b/inmem_transport.go
@@ -159,7 +159,7 @@ func (i *InmemTransport) makeRPC(target ServerAddress, args interface{}, r io.Re
 	}
 
 	// Send the RPC over
-	respCh := make(chan RPCResponse)
+	respCh := make(chan RPCResponse, 1)
 	req := RPC{
 		Command:  args,
 		Reader:   r,

--- a/raft.go
+++ b/raft.go
@@ -982,6 +982,7 @@ func (r *Raft) restoreUserSnapshot(meta *SnapshotMeta, reader io.Reader) error {
 	// Restore the snapshot into the FSM. If this fails we are in a
 	// bad state so we panic to take ourselves out.
 	fsm := &restoreFuture{ID: sink.ID()}
+	fsm.ShutdownCh = r.shutdownCh
 	fsm.init()
 	select {
 	case r.fsmMutateCh <- fsm:
@@ -1576,6 +1577,7 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 
 	// Restore snapshot
 	future := &restoreFuture{ID: sink.ID()}
+	future.ShutdownCh = r.shutdownCh
 	future.init()
 	select {
 	case r.fsmMutateCh <- future:

--- a/raft_test.go
+++ b/raft_test.go
@@ -208,7 +208,9 @@ func TestRaft_RecoverCluster(t *testing.T) {
 		c.EnsureSamePeers(t)
 	}
 	for applies := 0; applies < 20; applies++ {
-		runRecover(applies)
+		t.Run(fmt.Sprintf("%d applies", applies), func(t *testing.T) {
+			runRecover(applies)
+		})
 	}
 }
 

--- a/raft_test.go
+++ b/raft_test.go
@@ -1237,10 +1237,7 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 	}
 	defer reader.Close()
 	if err := leader.Restore(meta, reader, 5*time.Second); err != nil {
-		// Losing leadership is fine during restore
-		if err != ErrLeadershipLost {
-			c.FailNowf("Restore failed: %v", err)
-		}
+		c.FailNowf("Restore failed: %v", err)
 	}
 
 	// Make sure the index was updated correctly. We add 2 because we burn

--- a/raft_test.go
+++ b/raft_test.go
@@ -1272,8 +1272,6 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 	}
 	fsm.Unlock()
 
-	// Make sure to get the possibly new leader
-	leader = c.Leader()
 	// Commit some more things.
 	for i := 20; i < 30; i++ {
 		future = leader.Apply([]byte(fmt.Sprintf("test %d", i)), 0)

--- a/testing.go
+++ b/testing.go
@@ -23,10 +23,10 @@ var (
 // Return configurations optimized for in-memory
 func inmemConfig(t *testing.T) *Config {
 	conf := DefaultConfig()
-	conf.HeartbeatTimeout = 100 * time.Millisecond
-	conf.ElectionTimeout = 100 * time.Millisecond
-	conf.LeaderLeaseTimeout = 100 * time.Millisecond
-	conf.CommitTimeout = 10 * time.Millisecond
+	conf.HeartbeatTimeout = 50 * time.Millisecond
+	conf.ElectionTimeout = 50 * time.Millisecond
+	conf.LeaderLeaseTimeout = 50 * time.Millisecond
+	conf.CommitTimeout = 5 * time.Millisecond
 	conf.Logger = newTestLeveledLogger(t)
 	return conf
 }

--- a/testing.go
+++ b/testing.go
@@ -23,10 +23,10 @@ var (
 // Return configurations optimized for in-memory
 func inmemConfig(t *testing.T) *Config {
 	conf := DefaultConfig()
-	conf.HeartbeatTimeout = 50 * time.Millisecond
-	conf.ElectionTimeout = 50 * time.Millisecond
-	conf.LeaderLeaseTimeout = 50 * time.Millisecond
-	conf.CommitTimeout = 5 * time.Millisecond
+	conf.HeartbeatTimeout = 100 * time.Millisecond
+	conf.ElectionTimeout = 100 * time.Millisecond
+	conf.LeaderLeaseTimeout = 100 * time.Millisecond
+	conf.CommitTimeout = 10 * time.Millisecond
 	conf.Logger = newTestLeveledLogger(t)
 	return conf
 }


### PR DESCRIPTION
This PR will print all goroutines when the tests panic and it also add support for golang 1.13.

On top of that there are some more fixed tests now:

* TestRaft_SnapshotRestore_PeerChange: This test was blocked on writing back the response into the channel from the RPC by a follower. Fixed by making it a buffered channel of size 1 and by changing the future to react to raft shutdown.
* TestRaft_UserRestore: before it would error when leadership changes because of the restore which is entirely possible though.