### PR TITLE
Deflake TestRaft_UserRestore

### DIFF
--- a/inmem_transport.go
+++ b/inmem_transport.go
@@ -63,7 +63,7 @@ func NewInmemTransportWithTimeout(addr ServerAddress, timeout time.Duration) (Se
 // NewInmemTransport is used to initialize a new transport
 // and generates a random local address if none is specified
 func NewInmemTransport(addr ServerAddress) (ServerAddress, *InmemTransport) {
-	return NewInmemTransportWithTimeout(addr, 50*time.Millisecond)
+	return NewInmemTransportWithTimeout(addr, 500*time.Millisecond)
 }
 
 // SetHeartbeatHandler is used to set optional fast-path for

--- a/testing.go
+++ b/testing.go
@@ -808,5 +808,6 @@ func FileSnapTest(t *testing.T) (string, *FileSnapshotStore) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	snap.noSync = true
 	return dir, snap
 }


### PR DESCRIPTION
This fixes flakiness in TestRaft_UserRestore by increasing timeouts and speeding up snapshot operations in tests.

Initially, snapshot tests use file snapshot operations with fsync to ensure crash resiliency (needed for production!), but this adds 50-80ms overhead in my laptop.  This can go against the leader election timeout of 50ms causing leadership election at Restore step of the test and failing.

Here, we increase the timeouts for the snapshot operation to 500ms, as file operations can be slow, and disable fsync invocation during unit/integration tests as we don't test crash recovery.

I've ran 92 test builds with the sha here.  None failed with this test.  32 builds failed with the following
```
  13 TestRaft_RecoverCluster
   6 TestRaft_Integ
   4 TestRaft_LeadershipTransferLeaderReplicationTimeout
   4 TestNetworkTransport_AppendEntriesPipeline_CloseStreams
   2 TestRaft_SnapshotRestore_PeerChange
   2 TestRaft_ProtocolVersion_Upgrade_1_2
   2 TestRaft_LeadershipTransferLeaderRejectsClientRequests
```
