### PR TITLE
Ignore non-voters in leadership transfer

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1734,13 +1734,13 @@ func (r *Raft) lookupServer(id ServerID) *Server {
 	return nil
 }
 
-// pickServer returns the follower that is most up to date. Because it accesses
-// leaderstate, it should only be called from the leaderloop.
+// pickServer returns the follower that is most up to date and participating in quorum.
+// Because it accesses leaderstate, it should only be called from the leaderloop.
 func (r *Raft) pickServer() *Server {
 	var pick *Server
 	var current uint64
 	for _, server := range r.configurations.latest.Servers {
-		if server.ID == r.localID {
+		if server.ID == r.localID || server.Suffrage != Voter {
 			continue
 		}
 		state, ok := r.leaderState.replState[server.ID]

--- a/raft_test.go
+++ b/raft_test.go
@@ -2094,6 +2094,29 @@ func TestRaft_LeadershipTransferLeaderReplicationTimeout(t *testing.T) {
 	}
 }
 
+func TestRaft_LeadershipTransferIgnoresNonvoters(t *testing.T) {
+	c := MakeCluster(2, t, nil)
+	defer c.Close()
+
+	follower := c.Followers()[0]
+
+	demoteFuture := c.Leader().DemoteVoter(follower.localID, 0, 1*time.Nanosecond)
+	if demoteFuture.Error() != nil {
+		t.Fatalf("demote voter err'd: %v", demoteFuture.Error())
+	}
+
+	future := c.Leader().LeadershipTransfer()
+	if future.Error() == nil {
+		t.Fatal("leadership transfer should err")
+	}
+
+	expected := "cannot find peer"
+	actual := future.Error().Error()
+	if !strings.Contains(actual, expected) {
+		t.Errorf("leadership transfer should err with: %s", expected)
+	}
+}
+
 func TestRaft_LeadershipTransferStopRightAway(t *testing.T) {
 	r := Raft{leaderState: leaderState{}}
 	r.setupLeaderState()

--- a/raft_test.go
+++ b/raft_test.go
@@ -2100,7 +2100,7 @@ func TestRaft_LeadershipTransferIgnoresNonvoters(t *testing.T) {
 
 	follower := c.Followers()[0]
 
-	demoteFuture := c.Leader().DemoteVoter(follower.localID, 0, 1*time.Nanosecond)
+	demoteFuture := c.Leader().DemoteVoter(follower.localID, 0, 0)
 	if demoteFuture.Error() != nil {
 		t.Fatalf("demote voter err'd: %v", demoteFuture.Error())
 	}


### PR DESCRIPTION
A leader should not initiate an election on a non-voter, causing it to temporarily become a leader for a short period of time.