### PR TITLE
Return decoded candidate address on duplicate requestVote log

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1452,7 +1452,7 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 	if lastVoteTerm == req.Term && lastVoteCandBytes != nil {
 		r.logger.Info("duplicate requestVote for same term", "term", req.Term)
 		if bytes.Compare(lastVoteCandBytes, req.Candidate) == 0 {
-			r.logger.Warn("duplicate requestVote from", "candidate", r.trans.DecodePeer(req.Candidate))
+			r.logger.Warn("duplicate requestVote from", "candidate", candidate)
 			resp.Granted = true
 		}
 		return

--- a/raft.go
+++ b/raft.go
@@ -1452,7 +1452,7 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 	if lastVoteTerm == req.Term && lastVoteCandBytes != nil {
 		r.logger.Info("duplicate requestVote for same term", "term", req.Term)
 		if bytes.Compare(lastVoteCandBytes, req.Candidate) == 0 {
-			r.logger.Warn("duplicate requestVote from", "candidate", req.Candidate)
+			r.logger.Warn("duplicate requestVote from", "candidate", r.trans.DecodePeer(req.Candidate))
 			resp.Granted = true
 		}
 		return


### PR DESCRIPTION
The log returns the encoded candidate address on the `duplicate requestVote from` warning message which is not very useful during triage:
```
2020-04-28T18:21:24.265Z [WARN]  storage.raft: duplicate requestVote from: candidate=[91, 58, 58, 93, 58, 56, 50, 48, 49]
```