### PR TITLE
Observe missed heartbeats

### DIFF
--- a/observer.go
+++ b/observer.go
@@ -1,8 +1,8 @@
 package raft
 
 import (
-	"time"
 	"sync/atomic"
+	"time"
 )
 
 // Observation is sent along the given channel to observers when an event occurs.
@@ -30,7 +30,7 @@ type PeerObservation struct {
 
 // FailedHeartbeatObservation is sent when a node fails to heartbeat with the leader
 type FailedHeartbeatObservation struct {
-	PeerID ServerID
+	PeerID      ServerID
 	LastContact time.Time
 }
 

--- a/observer.go
+++ b/observer.go
@@ -27,8 +27,8 @@ type PeerObservation struct {
 	Peer    Server
 }
 
-// HeartbeatObservation is sent when a node fails to heartbeat with the leader
-type HeartbeatObservation struct {
+// MissedHeartbeatObservation is sent when a node fails to heartbeat with the leader
+type MissedHeartbeatObservation struct {
 	PeerID ServerID
 }
 

--- a/observer.go
+++ b/observer.go
@@ -27,6 +27,7 @@ type PeerObservation struct {
 	Peer    Server
 }
 
+// HeartbeatObservation is sent when a node fails to heartbeat with the leader
 type HeartbeatObservation struct {
 	Peer ServerAddress
 }

--- a/observer.go
+++ b/observer.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"time"
 	"sync/atomic"
 )
 
@@ -30,6 +31,7 @@ type PeerObservation struct {
 // FailedHeartbeatObservation is sent when a node fails to heartbeat with the leader
 type FailedHeartbeatObservation struct {
 	PeerID ServerID
+	LastContact time.Time
 }
 
 // nextObserverId is used to provide a unique ID for each observer to aid in

--- a/observer.go
+++ b/observer.go
@@ -27,8 +27,8 @@ type PeerObservation struct {
 	Peer    Server
 }
 
-// MissedHeartbeatObservation is sent when a node fails to heartbeat with the leader
-type MissedHeartbeatObservation struct {
+// FailedHeartbeatObservation is sent when a node fails to heartbeat with the leader
+type FailedHeartbeatObservation struct {
 	PeerID ServerID
 }
 

--- a/observer.go
+++ b/observer.go
@@ -27,6 +27,10 @@ type PeerObservation struct {
 	Peer    Server
 }
 
+type HeartbeatObservation struct {
+	Peer ServerAddress
+}
+
 // nextObserverId is used to provide a unique ID for each observer to aid in
 // deregistration.
 var nextObserverID uint64

--- a/observer.go
+++ b/observer.go
@@ -29,7 +29,7 @@ type PeerObservation struct {
 
 // HeartbeatObservation is sent when a node fails to heartbeat with the leader
 type HeartbeatObservation struct {
-	Peer ServerAddress
+	PeerID ServerID
 }
 
 // nextObserverId is used to provide a unique ID for each observer to aid in

--- a/raft.go
+++ b/raft.go
@@ -882,7 +882,7 @@ func (r *Raft) checkLeaderLease() time.Duration {
 					r.logger.Debug("failed to contact", "server-id", server.ID, "time", diff)
 				}
 
-				r.observe(HeartbeatObservation{PeerID: server.ID})
+				r.observe(MissedHeartbeatObservation{PeerID: server.ID})
 			}
 			metrics.AddSample([]string{"raft", "leader", "lastContact"}, float32(diff/time.Millisecond))
 		}

--- a/raft.go
+++ b/raft.go
@@ -882,7 +882,7 @@ func (r *Raft) checkLeaderLease() time.Duration {
 					r.logger.Debug("failed to contact", "server-id", server.ID, "time", diff)
 				}
 
-				r.observe(MissedHeartbeatObservation{PeerID: server.ID})
+				r.observe(FailedHeartbeatObservation{PeerID: server.ID})
 			}
 			metrics.AddSample([]string{"raft", "leader", "lastContact"}, float32(diff/time.Millisecond))
 		}

--- a/raft.go
+++ b/raft.go
@@ -881,6 +881,8 @@ func (r *Raft) checkLeaderLease() time.Duration {
 				} else {
 					r.logger.Debug("failed to contact", "server-id", server.ID, "time", diff)
 				}
+
+				r.observe(HeartbeatObservation{ Peer: server.Address})
 			}
 			metrics.AddSample([]string{"raft", "leader", "lastContact"}, float32(diff/time.Millisecond))
 		}

--- a/raft.go
+++ b/raft.go
@@ -882,7 +882,7 @@ func (r *Raft) checkLeaderLease() time.Duration {
 					r.logger.Debug("failed to contact", "server-id", server.ID, "time", diff)
 				}
 
-				r.observe(FailedHeartbeatObservation{PeerID: server.ID})
+				r.observe(FailedHeartbeatObservation{PeerID: server.ID, LastContact: f.LastContact()})
 			}
 			metrics.AddSample([]string{"raft", "leader", "lastContact"}, float32(diff/time.Millisecond))
 		}

--- a/raft.go
+++ b/raft.go
@@ -881,8 +881,6 @@ func (r *Raft) checkLeaderLease() time.Duration {
 				} else {
 					r.logger.Debug("failed to contact", "server-id", server.ID, "time", diff)
 				}
-
-				r.observe(FailedHeartbeatObservation{PeerID: server.ID, LastContact: f.LastContact()})
 			}
 			metrics.AddSample([]string{"raft", "leader", "lastContact"}, float32(diff/time.Millisecond))
 		}

--- a/raft.go
+++ b/raft.go
@@ -882,7 +882,7 @@ func (r *Raft) checkLeaderLease() time.Duration {
 					r.logger.Debug("failed to contact", "server-id", server.ID, "time", diff)
 				}
 
-				r.observe(HeartbeatObservation{Peer: server.Address})
+				r.observe(HeartbeatObservation{PeerID: server.ID})
 			}
 			metrics.AddSample([]string{"raft", "leader", "lastContact"}, float32(diff/time.Millisecond))
 		}

--- a/raft.go
+++ b/raft.go
@@ -882,7 +882,7 @@ func (r *Raft) checkLeaderLease() time.Duration {
 					r.logger.Debug("failed to contact", "server-id", server.ID, "time", diff)
 				}
 
-				r.observe(HeartbeatObservation{ Peer: server.Address})
+				r.observe(HeartbeatObservation{Peer: server.Address})
 			}
 			metrics.AddSample([]string{"raft", "leader", "lastContact"}, float32(diff/time.Millisecond))
 		}

--- a/replication.go
+++ b/replication.go
@@ -378,6 +378,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 		start := time.Now()
 		if err := r.trans.AppendEntries(s.peer.ID, s.peer.Address, &req, &resp); err != nil {
 			r.logger.Error("failed to heartbeat to", "peer", s.peer.Address, "error", err)
+			r.observe(FailedHeartbeatObservation{PeerID: server.ID, LastContact: s.LastContact()})
 			failures++
 			select {
 			case <-time.After(backoff(failureWait, failures, maxFailureScale)):

--- a/replication.go
+++ b/replication.go
@@ -378,7 +378,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 		start := time.Now()
 		if err := r.trans.AppendEntries(s.peer.ID, s.peer.Address, &req, &resp); err != nil {
 			r.logger.Error("failed to heartbeat to", "peer", s.peer.Address, "error", err)
-			r.observe(FailedHeartbeatObservation{PeerID: server.ID, LastContact: s.LastContact()})
+			r.observe(FailedHeartbeatObservation{PeerID: s.peer.ID, LastContact: s.LastContact()})
 			failures++
 			select {
 			case <-time.After(backoff(failureWait, failures, maxFailureScale)):


### PR DESCRIPTION
From the perspective of a Raft API user, there is currently no way to detect if the leader is unable to contact nodes. This PR allows users to register an observer that will make observations whenever the leader cannot heartbeat with a node.

Fixes issue #401 