### PR TITLE
do not include peer in metrics name

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -572,8 +572,8 @@ func (r *Raft) setNewLogs(req *AppendEntriesRequest, nextIndex, lastIndex uint64
 
 // appendStats is used to emit stats about an AppendEntries invocation.
 func appendStats(peer string, start time.Time, logs float32) {
-	metrics.MeasureSince([]string{"raft", "replication", "appendEntries", "rpc", peer}, start)
-	metrics.IncrCounter([]string{"raft", "replication", "appendEntries", "logs", peer}, logs)
+	metrics.MeasureSince([]string{"raft", "replication", "appendEntries", "rpc"}, start)
+	metrics.IncrCounter([]string{"raft", "replication", "appendEntries", "logs"}, logs)
 }
 
 // handleStaleTerm is used when a follower indicates that we have a stale term.


### PR DESCRIPTION
`consul_raft_replication_appendEntries_logs_02cdf4f2-cd58-f119-9a5f-36382cb73c44` vs `consul_raft_replication_appendEntries_logs`.