### PR TITLE
Use peer id as metric label

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -328,6 +328,8 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 	}
 	labels := []metrics.Label{{Name: "peer_id", Value: string(s.peer.ID)}}
 	metrics.MeasureSinceWithLabels([]string{"raft", "replication", "installSnapshot"}, start, labels)
+	// Duplicated information. Kept for backward compatibility.
+	metrics.MeasureSince([]string{"raft", "replication", "installSnapshot", string(s.peer.ID)}, start)
 
 	// Check for a newer term, stop running
 	if resp.Term > req.Term {
@@ -389,6 +391,8 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			failures = 0
 			labels := []metrics.Label{{Name: "peer_id", Value: string(s.peer.ID)}}
 			metrics.MeasureSinceWithLabels([]string{"raft", "replication", "heartbeat"}, start, labels)
+			// Duplicated information. Kept for backward compatibility.
+			metrics.MeasureSince([]string{"raft", "replication", "heartbeat", string(s.peer.ID)}, start)
 			s.notifyAll(resp.Success)
 		}
 	}
@@ -577,6 +581,9 @@ func appendStats(peer string, start time.Time, logs float32) {
 	labels := []metrics.Label{{Name: "peer_id", Value: peer}}
 	metrics.MeasureSinceWithLabels([]string{"raft", "replication", "appendEntries", "rpc"}, start, labels)
 	metrics.IncrCounterWithLabels([]string{"raft", "replication", "appendEntries", "logs"}, logs, labels)
+	// Duplicated information. Kept for backward compatibility.
+	metrics.MeasureSince([]string{"raft", "replication", "appendEntries", "rpc", peer}, start)
+	metrics.IncrCounter([]string{"raft", "replication", "appendEntries", "logs", peer}, logs)
 }
 
 // handleStaleTerm is used when a follower indicates that we have a stale term.

--- a/replication.go
+++ b/replication.go
@@ -326,7 +326,8 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 		s.failures++
 		return false, err
 	}
-	metrics.MeasureSince([]string{"raft", "replication", "installSnapshot", string(s.peer.ID)}, start)
+	labels := []metrics.Label{{Name: "peer_id", Value: string(s.peer.ID)}}
+	metrics.MeasureSinceWithLabels([]string{"raft", "replication", "installSnapshot"}, start, labels)
 
 	// Check for a newer term, stop running
 	if resp.Term > req.Term {
@@ -386,7 +387,8 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 		} else {
 			s.setLastContact()
 			failures = 0
-			metrics.MeasureSince([]string{"raft", "replication", "heartbeat", string(s.peer.ID)}, start)
+			labels := []metrics.Label{{Name: "peer_id", Value: string(s.peer.ID)}}
+			metrics.MeasureSinceWithLabels([]string{"raft", "replication", "heartbeat"}, start, labels)
 			s.notifyAll(resp.Success)
 		}
 	}
@@ -572,8 +574,9 @@ func (r *Raft) setNewLogs(req *AppendEntriesRequest, nextIndex, lastIndex uint64
 
 // appendStats is used to emit stats about an AppendEntries invocation.
 func appendStats(peer string, start time.Time, logs float32) {
-	metrics.MeasureSince([]string{"raft", "replication", "appendEntries", "rpc", peer}, start)
-	metrics.IncrCounter([]string{"raft", "replication", "appendEntries", "logs", peer}, logs)
+	labels := []metrics.Label{{Name: "peer_id", Value: peer}}
+	metrics.MeasureSinceWithLabels([]string{"raft", "replication", "appendEntries", "rpc"}, start, labels)
+	metrics.IncrCounterWithLabels([]string{"raft", "replication", "appendEntries", "logs"}, logs, labels)
 }
 
 // handleStaleTerm is used when a follower indicates that we have a stale term.


### PR DESCRIPTION
Hey! 
I'm currently working on the consul integration at Datadog, and we want to scrape the prometheus endpoint to get consul metrics. In the current state several metrics are not consistently named, and contain parts that would be good as labels instead, and that makes scraping the endpoint and converting to Datadog metrics troublesome.
This PR use the peer ids as label and remove them from the metric names.

Example: `consul_raft_replication_appendEntries_logs_684ad51c_6143_f2ea_aaaa_8ab6cc5ccccc` -> `consul_raft_replication_appendEntries_logs`.
This PR affects:
* `consul_raft_replication_installSnapshot`
* `consul_raft_replication_heartbeat`
* `consul_raft_replication_appendEntries_rpc`
* `consul_raft_replication_appendEntries_logs`

This change is not backward compatible since the metric names will be different. The current metric parsing method won't work anymore.

Please tell me what you think about this change! 😄 

P.S. : I'd like to do the same thing for other consul metrics (here for example https://github.com/hashicorp/consul/blob/5e5dbedd47a5f875b60e241c5555a9caab595246/agent/http.go#L258)