### PR TITLE
leader notifies followers for commitIndex in heartbeat rpc

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -375,6 +375,10 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			return
 		}
 
+		if !s.allowPipeline {
+			req.LeaderCommitIndex = r.getCommitIndex()
+		}
+
 		start := time.Now()
 		if err := r.trans.AppendEntries(s.peer.ID, s.peer.Address, &req, &resp); err != nil {
 			r.logger.Error("failed to heartbeat to", "peer", s.peer.Address, "error", err)


### PR DESCRIPTION
Hello. I think that the leader will not notify followers specially for commitIndex  except normal AppendEntriesRpc(not heartbeat), it will bring about follower's commitIndex is not latest. 
In the raft paper(section 5.3) it suggests the leader keeps track of the highest index it knows to be committed, and it includes that index in future AppendEntries RPCs (including heartbeats) so that the other servers eventually find out.
Is it right in my understand?
![image](https://user-images.githubusercontent.com/25179277/87871831-6efda880-c9e6-11ea-81ea-d386dee2396d.png)
