### PR TITLE
Reject leadership transfer requests when in candidate state

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -311,6 +311,10 @@ func (r *Raft) runCandidate() {
 			// Reject any restores since we are not the leader
 			r.respond(ErrNotLeader)
 
+		case r := <-r.leadershipTransferCh:
+			// Reject any operations since we are not the leader
+			r.respond(ErrNotLeader)
+
 		case c := <-r.configurationsCh:
 			c.configurations = r.configurations.Clone()
 			c.respond(nil)


### PR DESCRIPTION
If `raft.LeadershipTransfer().Error()` is called while raft is in candidate state the caller will block until it transitions to follower or leader. If raft is in an error state and unable to elect a leader this could block indefinitely. This PR causes `LeadershipTransfer()` called on a candidate node to immediately return an error.