### PR TITLE
error style fixes

### DIFF
--- a/config.go
+++ b/config.go
@@ -238,20 +238,20 @@ func ValidateConfig(config *Config) error {
 	}
 	if config.ProtocolVersion < protocolMin ||
 		config.ProtocolVersion > ProtocolVersionMax {
-		return fmt.Errorf("Protocol version %d must be >= %d and <= %d",
+		return fmt.Errorf("ProtocolVersion %d must be >= %d and <= %d",
 			config.ProtocolVersion, protocolMin, ProtocolVersionMax)
 	}
 	if len(config.LocalID) == 0 {
 		return fmt.Errorf("LocalID cannot be empty")
 	}
 	if config.HeartbeatTimeout < 5*time.Millisecond {
-		return fmt.Errorf("Heartbeat timeout is too low")
+		return fmt.Errorf("HeartbeatTimeout is too low")
 	}
 	if config.ElectionTimeout < 5*time.Millisecond {
-		return fmt.Errorf("Election timeout is too low")
+		return fmt.Errorf("ElectionTimeout is too low")
 	}
 	if config.CommitTimeout < time.Millisecond {
-		return fmt.Errorf("Commit timeout is too low")
+		return fmt.Errorf("CommitTimeout is too low")
 	}
 	if config.MaxAppendEntries <= 0 {
 		return fmt.Errorf("MaxAppendEntries must be positive")
@@ -260,16 +260,16 @@ func ValidateConfig(config *Config) error {
 		return fmt.Errorf("MaxAppendEntries is too large")
 	}
 	if config.SnapshotInterval < 5*time.Millisecond {
-		return fmt.Errorf("Snapshot interval is too low")
+		return fmt.Errorf("SnapshotInterval is too low")
 	}
 	if config.LeaderLeaseTimeout < 5*time.Millisecond {
-		return fmt.Errorf("Leader lease timeout is too low")
+		return fmt.Errorf("LeaderLeaseTimeout is too low")
 	}
 	if config.LeaderLeaseTimeout > config.HeartbeatTimeout {
-		return fmt.Errorf("Leader lease timeout cannot be larger than heartbeat timeout")
+		return fmt.Errorf("LeaderLeaseTimeout cannot be larger than heartbeat timeout")
 	}
 	if config.ElectionTimeout < config.HeartbeatTimeout {
-		return fmt.Errorf("Election timeout must be equal or greater than Heartbeat Timeout")
+		return fmt.Errorf("ElectionTimeout must be equal or greater than Heartbeat Timeout")
 	}
 	return nil
 }

--- a/configuration.go
+++ b/configuration.go
@@ -181,17 +181,17 @@ func checkConfiguration(configuration Configuration) error {
 	var voters int
 	for _, server := range configuration.Servers {
 		if server.ID == "" {
-			return fmt.Errorf("Empty ID in configuration: %v", configuration)
+			return fmt.Errorf("empty ID in configuration: %v", configuration)
 		}
 		if server.Address == "" {
-			return fmt.Errorf("Empty address in configuration: %v", server)
+			return fmt.Errorf("empty address in configuration: %v", server)
 		}
 		if idSet[server.ID] {
-			return fmt.Errorf("Found duplicate ID in configuration: %v", server.ID)
+			return fmt.Errorf("found duplicate ID in configuration: %v", server.ID)
 		}
 		idSet[server.ID] = true
 		if addressSet[server.Address] {
-			return fmt.Errorf("Found duplicate address in configuration: %v", server.Address)
+			return fmt.Errorf("found duplicate address in configuration: %v", server.Address)
 		}
 		addressSet[server.Address] = true
 		if server.Suffrage == Voter {
@@ -199,7 +199,7 @@ func checkConfiguration(configuration Configuration) error {
 		}
 	}
 	if voters == 0 {
-		return fmt.Errorf("Need at least one voter in configuration: %v", configuration)
+		return fmt.Errorf("need at least one voter in configuration: %v", configuration)
 	}
 	return nil
 }
@@ -209,7 +209,7 @@ func checkConfiguration(configuration Configuration) error {
 // that it can be unit tested easily.
 func nextConfiguration(current Configuration, currentIndex uint64, change configurationChangeRequest) (Configuration, error) {
 	if change.prevIndex > 0 && change.prevIndex != currentIndex {
-		return Configuration{}, fmt.Errorf("Configuration changed since %v (latest is %v)", change.prevIndex, currentIndex)
+		return Configuration{}, fmt.Errorf("configuration changed since %v (latest is %v)", change.prevIndex, currentIndex)
 	}
 
 	configuration := current.Clone()

--- a/fuzzy/partition_test.go
+++ b/fuzzy/partition_test.go
@@ -129,7 +129,7 @@ func (p *Partitioner) PreRPC(s, t string, r *raft.RPC) error {
 	if sp == st {
 		return nil
 	}
-	return fmt.Errorf("Unable to connect to %v, from %v", t, s)
+	return fmt.Errorf("unable to connect to %v, from %v", t, s)
 }
 
 func (p *Partitioner) PostRPC(s, t string, req *raft.RPC, res *raft.RPCResponse) error {

--- a/fuzzy/transport.go
+++ b/fuzzy/transport.go
@@ -101,7 +101,7 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 	if tt == nil {
 		t.log.Info("sendRPC unknown node", "target", target, "transports", t.transports.nodes)
 		t.transports.RUnlock()
-		return fmt.Errorf("Unknown target host %v", target)
+		return fmt.Errorf("unknown target host %v", target)
 	}
 	t.transports.RUnlock()
 	rc := make(chan raft.RPCResponse, 1)


### PR DESCRIPTION
Error strings should not be capitalized except it starts with a variable name.