### PR TITLE
Make snapshot meta size optional

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -95,6 +95,7 @@ func MakeRaft(t *testing.T, conf *Config, bootstrap bool) *RaftEnv {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	trans.TimeoutScale = 1000
 
 	env.logger = hclog.New(&hclog.LoggerOptions{
 		Name: string(trans.LocalAddr()) + " :",

--- a/raft.go
+++ b/raft.go
@@ -1563,7 +1563,7 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	}
 
 	// Check that we received it all
-	if n != req.Size {
+	if req.Size != 0 && n != req.Size {
 		sink.Cancel()
 		r.logger.Error("failed to receive whole snapshot",
 			"received", hclog.Fmt("%d / %d", n, req.Size))


### PR DESCRIPTION
Desired for Vault snapshotting where it's expensive to compute size.
Changes seem to work, but unclear if the LimitReader was necessary - is the connection re-used?