### PR TITLE
[FIXED] LogCache should not cache on StoreLogs error

### DIFF
--- a/log_cache.go
+++ b/log_cache.go
@@ -51,14 +51,16 @@ func (c *LogCache) StoreLog(log *Log) error {
 }
 
 func (c *LogCache) StoreLogs(logs []*Log) error {
-	// Insert the logs into the ring buffer
-	c.l.Lock()
-	for _, l := range logs {
-		c.cache[l.Index%uint64(len(c.cache))] = l
+	err := c.store.StoreLogs(logs)
+	// Insert the logs into the ring buffer, but only on success
+	if err == nil {
+		c.l.Lock()
+		for _, l := range logs {
+			c.cache[l.Index%uint64(len(c.cache))] = l
+		}
+		c.l.Unlock()
 	}
-	c.l.Unlock()
-
-	return c.store.StoreLogs(logs)
+	return err
 }
 
 func (c *LogCache) FirstIndex() (uint64, error) {


### PR DESCRIPTION
LogCache was caching logs and then invoking store.StoreLogs().
However, if StoreLogs() fails to store, LogCache.Get() could still
return logs that had not been persisted into storage, which could
lead to a node failing to restart with a "log not found" panic.

This PR ensures that LogCache only cache logs if StoreLogs was
successful.

Resolves #429

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>