### PR TITLE
Make snapshot timing and trailing logs hot-reloadable in raft

### DIFF
--- a/api.go
+++ b/api.go
@@ -642,7 +642,9 @@ func (r *Raft) config() Config {
 	return r.conf.Load().(Config)
 }
 
-// ReloadConfig updates the configuration of a running raft node.
+// ReloadConfig updates the configuration of a running raft node. If the new
+// configuration is invalid an error is returned and no changes made to the
+// instance.
 func (r *Raft) ReloadConfig(rc *ReloadableConfig) error {
 	r.confReloadMu.Lock()
 	defer r.confReloadMu.Unlock()

--- a/api.go
+++ b/api.go
@@ -81,8 +81,15 @@ type Raft struct {
 	// be committed and applied to the FSM.
 	applyCh chan *logFuture
 
-	// Configuration provided at Raft initialization
-	conf Config
+	// conf stores the current configuration to use. This is the most recent one
+	// provided. All reads of config values should use the config() helper method
+	// to read this safely.
+	conf atomic.Value
+
+	// confReloadMu ensures that only one thread can reload config at once since
+	// we need to read-modify-write the atomic. It is NOT necessary to hold this
+	// for any other operation e.g. reading config using config().
+	confReloadMu sync.Mutex
 
 	// FSM is the client state machine to apply commands to
 	fsm FSM
@@ -385,9 +392,9 @@ func RecoverCluster(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 	return nil
 }
 
-// GetConfiguration returns the configuration of the Raft cluster without
-// starting a Raft instance or connecting to the cluster
-// This function has identical behavior to Raft.GetConfiguration
+// GetConfiguration returns the persisted configuration of the Raft cluster
+// without starting a Raft instance or connecting to the cluster. This function
+// has identical behavior to Raft.GetConfiguration.
 func GetConfiguration(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 	snaps SnapshotStore, trans Transport) (Configuration, error) {
 	conf.skipStartup = true
@@ -505,7 +512,6 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	r := &Raft{
 		protocolVersion:       protocolVersion,
 		applyCh:               applyCh,
-		conf:                  *conf,
 		fsm:                   fsm,
 		fsmMutateCh:           make(chan interface{}, 128),
 		fsmSnapshotCh:         make(chan *reqSnapshotFuture),
@@ -529,6 +535,8 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 		observers:             make(map[uint64]*Observer),
 		leadershipTransferCh:  make(chan *leadershipTransferFuture, 1),
 	}
+
+	r.conf.Store(*conf)
 
 	// Initialize as a follower.
 	r.setState(Follower)
@@ -583,7 +591,7 @@ func (r *Raft) restoreSnapshot() error {
 
 	// Try to load in order of newest to oldest
 	for _, snapshot := range snapshots {
-		if !r.conf.NoSnapshotRestoreOnStart {
+		if !r.config().NoSnapshotRestoreOnStart {
 			_, source, err := r.snapshots.Open(snapshot.ID)
 			if err != nil {
 				r.logger.Error("failed to open snapshot", "id", snapshot.ID, "error", err)
@@ -627,6 +635,29 @@ func (r *Raft) restoreSnapshot() error {
 	if len(snapshots) > 0 {
 		return fmt.Errorf("failed to load any existing snapshots")
 	}
+	return nil
+}
+
+func (r *Raft) config() Config {
+	return r.conf.Load().(Config)
+}
+
+// ReloadConfig updates the configuration of a running raft node.
+func (r *Raft) ReloadConfig(rc *ReloadableConfig) error {
+	r.confReloadMu.Lock()
+	defer r.confReloadMu.Unlock()
+
+	// Load the current config (note we are under a lock so it can't be changed
+	// between this read and a later Store).
+	oldCfg := r.config()
+
+	// Set the reloadable fields
+	newCfg := rc.apply(oldCfg)
+
+	if err := ValidateConfig(&newCfg); err != nil {
+		return err
+	}
+	r.conf.Store(newCfg)
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -167,17 +167,20 @@ type Config struct {
 	// TrailingLogs controls how many logs we leave after a snapshot. This is used
 	// so that we can quickly replay logs on a follower instead of being forced to
 	// send an entire snapshot. The value passed here is the initial setting used.
-	// This can be tuned during operation using
+	// This can be tuned during operation using ReloadConfig.
 	TrailingLogs uint64
 
-	// SnapshotInterval controls how often we check if we should perform a snapshot.
-	// We randomly stagger between this value and 2x this value to avoid the entire
-	// cluster from performing a snapshot at once.
+	// SnapshotInterval controls how often we check if we should perform a
+	// snapshot. We randomly stagger between this value and 2x this value to avoid
+	// the entire cluster from performing a snapshot at once. The value passed
+	// here is the initial setting used. This can be tuned during operation using
+	// ReloadConfig.
 	SnapshotInterval time.Duration
 
 	// SnapshotThreshold controls how many outstanding logs there must be before
 	// we perform a snapshot. This is to prevent excessive snapshots when we can
-	// just replay a small set of logs.
+	// just replay a small set of logs. The value passed here is the initial
+	// setting used. This can be tuned during operation using ReloadConfig.
 	SnapshotThreshold uint64
 
 	// LeaderLeaseTimeout is used to control how long the "lease" lasts

--- a/config.go
+++ b/config.go
@@ -164,9 +164,10 @@ type Config struct {
 	// we can become a leader of a cluster containing only this node.
 	ShutdownOnRemove bool
 
-	// TrailingLogs controls how many logs we leave after a snapshot. This is
-	// used so that we can quickly replay logs on a follower instead of being
-	// forced to send an entire snapshot.
+	// TrailingLogs controls how many logs we leave after a snapshot. This is used
+	// so that we can quickly replay logs on a follower instead of being forced to
+	// send an entire snapshot. The value passed here is the initial setting used.
+	// This can be tuned during operation using
 	TrailingLogs uint64
 
 	// SnapshotInterval controls how often we check if we should perform a snapshot.
@@ -216,6 +217,39 @@ type Config struct {
 
 	// skipStartup allows NewRaft() to bypass all background work goroutines
 	skipStartup bool
+}
+
+// ReloadableConfig is the subset of Config that may be reconfigured during
+// runtime using raft.ReloadConfig. We choose to duplicate fields over embedding
+// or accepting a Config but only using specific fields to keep the API clear.
+// Reconfiguring some fields is potentially dangerous so we should only
+// selectively enable it for fields where that is allowed.
+type ReloadableConfig struct {
+	// TrailingLogs controls how many logs we leave after a snapshot. This is used
+	// so that we can quickly replay logs on a follower instead of being forced to
+	// send an entire snapshot. The value passed here is the initial setting used.
+	// This can be tuned during operation using
+	TrailingLogs uint64
+
+	// SnapshotInterval controls how often we check if we should perform a snapshot.
+	// We randomly stagger between this value and 2x this value to avoid the entire
+	// cluster from performing a snapshot at once.
+	SnapshotInterval time.Duration
+
+	// SnapshotThreshold controls how many outstanding logs there must be before
+	// we perform a snapshot. This is to prevent excessive snapshots when we can
+	// just replay a small set of logs.
+	SnapshotThreshold uint64
+}
+
+// apply sets the reloadable fields on the passed Config to the values in
+// `ReloadableConfig`. It returns a copy of Config with the fields from this
+// ReloadableConfig set.
+func (rc *ReloadableConfig) apply(to Config) Config {
+	to.TrailingLogs = rc.TrailingLogs
+	to.SnapshotInterval = rc.SnapshotInterval
+	to.SnapshotThreshold = rc.SnapshotThreshold
+	return to
 }
 
 // DefaultConfig returns a Config with usable defaults.

--- a/config.go
+++ b/config.go
@@ -230,8 +230,9 @@ type Config struct {
 type ReloadableConfig struct {
 	// TrailingLogs controls how many logs we leave after a snapshot. This is used
 	// so that we can quickly replay logs on a follower instead of being forced to
-	// send an entire snapshot. The value passed here is the initial setting used.
-	// This can be tuned during operation using
+	// send an entire snapshot. The value passed here updates the setting at runtime
+	// which will take effect as soon as the next snapshot completes and truncation
+	// occurs.
 	TrailingLogs uint64
 
 	// SnapshotInterval controls how often we check if we should perform a snapshot.

--- a/replication.go
+++ b/replication.go
@@ -161,7 +161,7 @@ RPC:
 		// raft commits stop flowing naturally. The actual heartbeats
 		// can't do this to keep them unblocked by disk IO on the
 		// follower. See https://github.com/hashicorp/raft/issues/282.
-		case <-randomTimeout(r.conf.CommitTimeout):
+		case <-randomTimeout(r.config().CommitTimeout):
 			lastLogIdx, _ := r.getLastLog()
 			shouldStop = r.replicateTo(s, lastLogIdx)
 		}
@@ -373,7 +373,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 		// Wait for the next heartbeat interval or forced notify
 		select {
 		case <-s.notifyCh:
-		case <-randomTimeout(r.conf.HeartbeatTimeout / 10):
+		case <-randomTimeout(r.config().HeartbeatTimeout / 10):
 		case <-stopCh:
 			return
 		}
@@ -447,7 +447,7 @@ SEND:
 		case <-s.triggerCh:
 			lastLogIdx, _ := r.getLastLog()
 			shouldStop = r.pipelineSend(s, pipeline, &nextIndex, lastLogIdx)
-		case <-randomTimeout(r.conf.CommitTimeout):
+		case <-randomTimeout(r.config().CommitTimeout):
 			lastLogIdx, _ := r.getLastLog()
 			shouldStop = r.pipelineSend(s, pipeline, &nextIndex, lastLogIdx)
 		}
@@ -562,9 +562,12 @@ func (r *Raft) setPreviousLog(req *AppendEntriesRequest, nextIndex uint64) error
 
 // setNewLogs is used to setup the logs which should be appended for a request.
 func (r *Raft) setNewLogs(req *AppendEntriesRequest, nextIndex, lastIndex uint64) error {
-	// Append up to MaxAppendEntries or up to the lastIndex
-	req.Entries = make([]*Log, 0, r.conf.MaxAppendEntries)
-	maxIndex := min(nextIndex+uint64(r.conf.MaxAppendEntries)-1, lastIndex)
+	// Append up to MaxAppendEntries or up to the lastIndex. we need to use a
+	// consistent value for maxAppendEntries in the lines below in case it ever
+	// becomes reloadable.
+	maxAppendEntries := r.config().MaxAppendEntries
+	req.Entries = make([]*Log, 0, maxAppendEntries)
+	maxIndex := min(nextIndex+uint64(maxAppendEntries)-1, lastIndex)
 	for i := nextIndex; i <= maxIndex; i++ {
 		oldLog := new(Log)
 		if err := r.logs.GetLog(i, oldLog); err != nil {

--- a/snapshot.go
+++ b/snapshot.go
@@ -69,7 +69,7 @@ type SnapshotSink interface {
 func (r *Raft) runSnapshots() {
 	for {
 		select {
-		case <-randomTimeout(r.conf.SnapshotInterval):
+		case <-randomTimeout(r.config().SnapshotInterval):
 			// Check if we should snapshot
 			if !r.shouldSnapshot() {
 				continue
@@ -113,7 +113,7 @@ func (r *Raft) shouldSnapshot() bool {
 
 	// Compare the delta to the threshold
 	delta := lastIdx - lastSnap
-	return delta >= r.conf.SnapshotThreshold
+	return delta >= r.config().SnapshotThreshold
 }
 
 // takeSnapshot is used to take a new snapshot. This must only be called from
@@ -219,7 +219,11 @@ func (r *Raft) compactLogs(snapIdx uint64) error {
 
 	// Check if we have enough logs to truncate
 	lastLogIdx, _ := r.getLastLog()
-	if lastLogIdx <= r.conf.TrailingLogs {
+
+	// Ise a consistent value for trailingLogs for the duration of this method
+	// call to avoid surprising behaviour.
+	trailingLogs := r.config().TrailingLogs
+	if lastLogIdx <= trailingLogs {
 		return nil
 	}
 
@@ -227,7 +231,7 @@ func (r *Raft) compactLogs(snapIdx uint64) error {
 	// back from the head, which ever is further back. This ensures
 	// at least `TrailingLogs` entries, but does not allow logs
 	// after the snapshot to be removed.
-	maxLog := min(snapIdx, lastLogIdx-r.conf.TrailingLogs)
+	maxLog := min(snapIdx, lastLogIdx-trailingLogs)
 
 	if minLog > maxLog {
 		r.logger.Info("no logs to truncate")

--- a/snapshot.go
+++ b/snapshot.go
@@ -220,7 +220,7 @@ func (r *Raft) compactLogs(snapIdx uint64) error {
 	// Check if we have enough logs to truncate
 	lastLogIdx, _ := r.getLastLog()
 
-	// Ise a consistent value for trailingLogs for the duration of this method
+	// Use a consistent value for trailingLogs for the duration of this method
 	// call to avoid surprising behaviour.
 	trailingLogs := r.config().TrailingLogs
 	if lastLogIdx <= trailingLogs {


### PR DESCRIPTION
These parameters are reasonably easy to make reloadable in a running raft instance.

Other parameters like the timeouts may be too although some require more thought about whether they are safe to change at runtime, however I'm sticking with these three right now as they are the critical parameters needed to get out of an otherwise unrecoverable situation detailed in https://github.com/hashicorp/consul/issues/9609.

There are other possible mitigations and solutions to that problem including my previous WIP PR that prevents snapshotting during replication entirely, but this has fewer uncertainties about safety and is the simplest change that gives a manual intervention option where almost none exists today.

If others are happy with this change, we can merge it and then allow Consul (and others) to have a way to re-configure snapshotting and log pruning on a leader without restarting it and loosing leadership.

## Open Questions

The API/Config change was the main gross part here. I went with this as the least-bad of a few bad options but I'm open to input if others thing there is a preferable way.

I didn't want to accept a whole `Config` even though some fields are not reloadable because then you either have to explicitly copy only some fields, or require the user ensure the rest of the config is identical to the current config (which they might not know as they can't read it) otherwise Bad Things would happen.

I also didn't want to make a separate `SetX` method for every field we make reloadable as I could see why at least a handful of others might be good to be reloadable later.

I also didn't want the internal state to continue reading from a plane `conf Config` field but just have to remember not to read reloadable fields from there but somewhere else because that seems error prone. This way forces all readers to access the most recent config and hopefully helps them consider whether the thing they are reading is reloadable or not so they can make sure the logic takes that into account (i.e. use same value in multiple operations in case it changes between them).
