### PR TITLE
Allow buffered applyCh

### DIFF
--- a/api.go
+++ b/api.go
@@ -495,6 +495,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 		return nil, fmt.Errorf("when running with ProtocolVersion < 3, LocalID must be set to the network address")
 	}
 
+	// Buffer applyCh to MaxAppendEntries if the option is enabled
 	applyCh := make(chan *logFuture)
 	if conf.BatchApplyCh {
 		applyCh = make(chan *logFuture, conf.MaxAppendEntries)

--- a/api.go
+++ b/api.go
@@ -495,10 +495,15 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 		return nil, fmt.Errorf("when running with ProtocolVersion < 3, LocalID must be set to the network address")
 	}
 
+	applyCh := make(chan *logFuture)
+	if conf.BatchApplyCh {
+		applyCh = make(chan *logFuture, conf.MaxAppendEntries)
+	}
+
 	// Create Raft struct.
 	r := &Raft{
 		protocolVersion:       protocolVersion,
-		applyCh:               make(chan *logFuture),
+		applyCh:               applyCh,
 		conf:                  *conf,
 		fsm:                   fsm,
 		fsmMutateCh:           make(chan interface{}, 128),

--- a/config.go
+++ b/config.go
@@ -151,6 +151,13 @@ type Config struct {
 	// an inconsistent log.
 	MaxAppendEntries int
 
+	// BatchApplyCh indicates whether we should buffer applyCh
+	// to size MaxAppendEntries. This enables batch log commitment,
+	// but breaks the timeout guarantee on Apply. Specifically,
+	// a log can be added to the applyCh buffer but not actually be
+	// processed until after the specified timeout.
+	BatchApplyCh bool
+
 	// If we are a member of a cluster, and RemovePeer is invoked for the
 	// local node, then we forget all peers and transition into the follower state.
 	// If ShutdownOnRemove is is set, we additional shutdown Raft. Otherwise,


### PR DESCRIPTION
This piggybacks off the discussion around https://github.com/hashicorp/raft/pull/124
While we acknowledge this discrepancy in timeout assumptions, it could still be valuable to at least expose the option to buffer the applyCh