### PR TITLE
Allow read of reloadable config values

### DIFF
--- a/api.go
+++ b/api.go
@@ -666,7 +666,10 @@ func (r *Raft) ReloadConfig(rc ReloadableConfig) error {
 
 // ReloadableConfig returns the current state of the reloadable fields in Raft's
 // configuration. This is useful for programs to discover the current state for
-// reporting to users or tests. It is safe to call from any goroutine.
+// reporting to users or tests. It is safe to call from any goroutine. It is intended
+// for reporting and testing purposes primarily; external synchronization would be
+// required to safely use this in a read-modify-write pattern for reloadable 
+// configuration options.
 func (r *Raft) ReloadableConfig() ReloadableConfig {
 	cfg := r.config()
 	var rc ReloadableConfig

--- a/api.go
+++ b/api.go
@@ -664,6 +664,16 @@ func (r *Raft) ReloadConfig(rc ReloadableConfig) error {
 	return nil
 }
 
+// ReloadableConfig returns the current state of the reloadable fields in Raft's
+// configuration. This is useful for programs to discover the current state for
+// reporting to users or tests. It is safe to call from any goroutine.
+func (r *Raft) ReloadableConfig() ReloadableConfig {
+	cfg := r.config()
+	var rc ReloadableConfig
+	rc.fromConfig(cfg)
+	return rc
+}
+
 // BootstrapCluster is equivalent to non-member BootstrapCluster but can be
 // called on an un-bootstrapped Raft instance after it has been created. This
 // should only be called at the beginning of time for the cluster with an

--- a/api.go
+++ b/api.go
@@ -666,10 +666,10 @@ func (r *Raft) ReloadConfig(rc ReloadableConfig) error {
 
 // ReloadableConfig returns the current state of the reloadable fields in Raft's
 // configuration. This is useful for programs to discover the current state for
-// reporting to users or tests. It is safe to call from any goroutine. It is intended
-// for reporting and testing purposes primarily; external synchronization would be
-// required to safely use this in a read-modify-write pattern for reloadable 
-// configuration options.
+// reporting to users or tests. It is safe to call from any goroutine. It is
+// intended for reporting and testing purposes primarily; external
+// synchronization would be required to safely use this in a read-modify-write
+// pattern for reloadable configuration options.
 func (r *Raft) ReloadableConfig() ReloadableConfig {
 	cfg := r.config()
 	var rc ReloadableConfig

--- a/config.go
+++ b/config.go
@@ -256,6 +256,13 @@ func (rc *ReloadableConfig) apply(to Config) Config {
 	return to
 }
 
+// fromConfig copies the reloadable fields from the passed Config.
+func (rc *ReloadableConfig) fromConfig(from Config) {
+	rc.TrailingLogs = from.TrailingLogs
+	rc.SnapshotInterval = from.SnapshotInterval
+	rc.SnapshotThreshold = from.SnapshotThreshold
+}
+
 // DefaultConfig returns a Config with usable defaults.
 func DefaultConfig() *Config {
 	return &Config{


### PR DESCRIPTION
Continuation of #444 this adds a method that allows callers to discover the current values of config in use for use in debugging and reporting APIs as well as being useful in tests.