### PR TITLE
Add a gauge to hold the last restore time that

### DIFF
--- a/api.go
+++ b/api.go
@@ -605,9 +605,11 @@ func (r *Raft) restoreSnapshot() error {
 			}
 
 			if err := fsmRestoreAndMeasure(r.fsm, source); err != nil {
+				source.Close()
 				r.logger.Error("failed to restore snapshot", "id", snapshot.ID, "error", err)
 				continue
 			}
+			source.Close()
 
 			r.logger.Info("restored from snapshot", "id", snapshot.ID)
 		}

--- a/api.go
+++ b/api.go
@@ -323,6 +323,7 @@ func RecoverCluster(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 			continue
 		}
 
+		start := time.Now()
 		err = fsm.Restore(source)
 		// Close the source after the restore has completed
 		source.Close()
@@ -330,6 +331,9 @@ func RecoverCluster(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 			// Same here, skip and try the next one.
 			continue
 		}
+		// Update the gauge for the time it took to restore.
+		metrics.SetGauge([]string{"raft", "fsm", "lastRestoreTime"},
+			float32(time.Since(start).Milliseconds()))
 
 		snapshotIndex = snapshot.Index
 		snapshotTerm = snapshot.Term
@@ -583,6 +587,11 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 // of them can be restored. This is called at initialization time, and is
 // completely unsafe to call at any other time.
 func (r *Raft) restoreSnapshot() error {
+	// Measure time from here since latency on listing snapshots or having to try
+	// multiple snapshots all adds to the restore time that matters i.e. how long
+	// the server takes to restart.
+	start := time.Now()
+
 	snapshots, err := r.snapshots.List()
 	if err != nil {
 		r.logger.Error("failed to list snapshots", "error", err)
@@ -608,6 +617,16 @@ func (r *Raft) restoreSnapshot() error {
 
 			r.logger.Info("restored from snapshot", "id", snapshot.ID)
 		}
+
+		// Update the gauge for the time it took to restore. We do this even if no
+		// actual restore happened since it's useful to always rely on the metric
+		// being set on startup. For persistent FSMs that use
+		// NoSnapshotRestoreOnStart this value will be low on initial startup, but
+		// could be set higher later if the node has to be restored from the
+		// leader. That's still useful information to see when operating a server.
+		metrics.SetGauge([]string{"raft", "fsm", "lastRestoreTime"},
+			float32(time.Since(start).Milliseconds()))
+
 		// Update the lastApplied so we don't replay old logs
 		r.setLastApplied(snapshot.Index)
 

--- a/fsm.go
+++ b/fsm.go
@@ -175,18 +175,13 @@ func (r *Raft) runFSM() {
 			req.respond(fmt.Errorf("failed to open snapshot %v: %v", req.ID, err))
 			return
 		}
+		defer source.Close()
 
 		// Attempt to restore
-		start := time.Now()
-		if err := r.fsm.Restore(source); err != nil {
+		if err := fsmRestoreAndMeasure(r.fsm, source); err != nil {
 			req.respond(fmt.Errorf("failed to restore snapshot %v: %v", req.ID, err))
-			source.Close()
 			return
 		}
-		source.Close()
-		metrics.MeasureSince([]string{"raft", "fsm", "restore"}, start)
-		metrics.SetGauge([]string{"raft", "fsm", "lastRestoreTime"},
-			float32(time.Since(start).Milliseconds()))
 
 		// Update the last index and term
 		lastIndex = meta.Index
@@ -234,4 +229,18 @@ func (r *Raft) runFSM() {
 			return
 		}
 	}
+}
+
+// fsmRestoreAndMeasure wraps the Restore call on an FSM to consistently measure
+// and report timing metrics. The caller is still responsible for calling Close
+// on the source in all cases.
+func fsmRestoreAndMeasure(fsm FSM, source io.ReadCloser) error {
+	start := time.Now()
+	if err := fsm.Restore(source); err != nil {
+		return err
+	}
+	metrics.MeasureSince([]string{"raft", "fsm", "restore"}, start)
+	metrics.SetGauge([]string{"raft", "fsm", "lastRestoreDuration"},
+		float32(time.Since(start).Milliseconds()))
+	return nil
 }

--- a/fsm.go
+++ b/fsm.go
@@ -185,6 +185,8 @@ func (r *Raft) runFSM() {
 		}
 		source.Close()
 		metrics.MeasureSince([]string{"raft", "fsm", "restore"}, start)
+		metrics.SetGauge([]string{"raft", "fsm", "lastRestoreTime"},
+			float32(time.Since(start).Milliseconds()))
 
 		// Update the last index and term
 		lastIndex = meta.Index


### PR DESCRIPTION
This is updated on every restore including startup from disk as well as RPC (leader/user initiated restore).

It's a gauge to provide a constant reading of the last restore time which may have been days or weeks ago in a healthy server but is useful to be able to graph along side the trailing logs age to check if there is danger of restores taking longer than trailing logs can cover.

It differs from fsm.restore both because it is omitted at startup and because it is a gauge rather than a single point in time sample.

This is a follow up to #452 (and relates to https://github.com/hashicorp/consul/issues/9609) after realising the current restore metrics are not really suitable to easily monitor whether the last restore too dangerously long or not!

Having this gauge means operators only need to compare two gauge values over time to get a good indicator of if their cluster is in danger of becoming unrecoverable.