### PR TITLE
Fix flaky TestRaft_LeadershipTransferLeaderRejectsClientRequests

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -347,10 +347,7 @@ func (r *Raft) setLeadershipTransferInProgress(v bool) {
 
 func (r *Raft) getLeadershipTransferInProgress() bool {
 	v := atomic.LoadInt32(&r.leaderState.leadershipTransferInProgress)
-	if v == 1 {
-		return true
-	}
-	return false
+	return v == 1
 }
 
 func (r *Raft) setupLeaderState() {

--- a/raft_test.go
+++ b/raft_test.go
@@ -2059,17 +2059,17 @@ func TestRaft_LeadershipTransferLeaderRejectsClientRequests(t *testing.T) {
 		l.requestConfigChange(configurationChangeRequest{}, 100*time.Millisecond),
 	}
 	futures = append(futures, l.LeadershipTransfer())
-	select {
-	case <-l.leadershipTransferCh:
-	default:
-	}
-
-	futures = append(futures, l.LeadershipTransferToServer(ServerID(""), ServerAddress("")))
 
 	for i, f := range futures {
+		t.Logf("waiting on future %v", i)
 		if f.Error() != ErrLeadershipTransferInProgress {
 			t.Errorf("case %d: should have errored with: %s, instead of %s", i, ErrLeadershipTransferInProgress, f.Error())
 		}
+	}
+
+	f := l.LeadershipTransferToServer(ServerID(""), ServerAddress(""))
+	if f.Error() != ErrLeadershipTransferInProgress {
+		t.Errorf("should have errored with: %s, instead of %s", ErrLeadershipTransferInProgress, f.Error())
 	}
 }
 

--- a/raft_test.go
+++ b/raft_test.go
@@ -123,7 +123,7 @@ func TestRaft_RecoverCluster(t *testing.T) {
 	// snapshot + log scenarios. By sweeping through the trailing logs value
 	// we will also hit the case where we have a snapshot only.
 	var err error
-	runRecover := func(applies int) {
+	runRecover := func(t *testing.T, applies int) {
 		conf := inmemConfig(t)
 		conf.TrailingLogs = 10
 		c := MakeCluster(3, t, conf)
@@ -213,7 +213,7 @@ func TestRaft_RecoverCluster(t *testing.T) {
 	}
 	for applies := 0; applies < 20; applies++ {
 		t.Run(fmt.Sprintf("%d applies", applies), func(t *testing.T) {
-			runRecover(applies)
+			runRecover(t, applies)
 		})
 	}
 }


### PR DESCRIPTION
This test is currently the test which flakes the most often.

The test would fail because of the select read-from-channel in the test. This
read-from-channel could race with the `leaderLoop` goroutine. If the
read-from-channel in the test won then the `leaderLoop` goroutine would
never receive the future, and the future would never respond, leaving the
test to timeout eventually.

The fix was to remove the select and read-from-channel from the test. This fix
caused the test to fail, because of the following call to `LeadershipTransferToServer`
would not being able to send to the channel immediately, resulting in an
ErrEnqueueTimeout instead of ErrLeadershipTransferInProgress.

To fix the secondary problem the test was changed to call
`LeadershipTransferToServer` after the channel is drained (by waiting on
all the futures).

Also added a `t.Logf` to the test, since that helped debug the problem I
thought it would be good to keep it around in case we encounter other
problems with this test.