### PR TITLE
[Updated] LogCache should not cache on StoreLogs error

### DIFF
--- a/log_cache.go
+++ b/log_cache.go
@@ -51,14 +51,17 @@ func (c *LogCache) StoreLog(log *Log) error {
 }
 
 func (c *LogCache) StoreLogs(logs []*Log) error {
-	// Insert the logs into the ring buffer
+	err := c.store.StoreLogs(logs)
+	// Insert the logs into the ring buffer, but only on success
+	if err != nil {
+		return fmt.Errorf("unable to store logs in log store, %v", err)
+	}
 	c.l.Lock()
 	for _, l := range logs {
 		c.cache[l.Index%uint64(len(c.cache))] = l
 	}
 	c.l.Unlock()
-
-	return c.store.StoreLogs(logs)
+	return nil
 }
 
 func (c *LogCache) FirstIndex() (uint64, error) {

--- a/log_cache.go
+++ b/log_cache.go
@@ -54,7 +54,7 @@ func (c *LogCache) StoreLogs(logs []*Log) error {
 	err := c.store.StoreLogs(logs)
 	// Insert the logs into the ring buffer, but only on success
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to store logs within log store, err: %q", err)
 	}
 	c.l.Lock()
 	for _, l := range logs {

--- a/log_cache_test.go
+++ b/log_cache_test.go
@@ -131,8 +131,8 @@ func TestLogCacheWithBackendStoreError(t *testing.T) {
 	errStore.failNext(1)
 	log := &Log{Index: 5}
 	err = c.StoreLog(log)
-	if !strings.Contains(err.Error(), "unable to store logs in log store") {
-		t.Fatalf("Should have returned unable to store logs in log store,  got err=%v", err)
+	if !strings.Contains(err.Error(), "some error") {
+		t.Fatalf("wanted: some error,  got err=%v", err)
 	}
 
 	var out Log

--- a/raft_test.go
+++ b/raft_test.go
@@ -2176,6 +2176,55 @@ func TestRaft_GetConfigurationNoBootstrap(t *testing.T) {
 	}
 }
 
+func TestRaft_CacheLogWithStoreError(t *testing.T) {
+	c := MakeCluster(2, t, nil)
+	defer c.Close()
+
+	// Should be one leader
+	follower := c.Followers()[0]
+	leader := c.Leader()
+	c.EnsureLeader(t, leader.localAddr)
+
+	// There is no lock to protect this assignment I am afraid.
+	es := &errorStore{LogStore: follower.logs}
+	cl, _ := NewLogCache(100, es)
+	follower.logs = cl
+
+	// Commit some logs
+	for i := 0; i < 5; i++ {
+		future := leader.Apply([]byte(fmt.Sprintf("test%d", i)), 0)
+		if err := future.Error(); err != nil {
+			c.FailNowf("[ERR] err: %v", err)
+		}
+	}
+
+	// Make the next fail
+	es.failNext(1)
+	leader.Apply([]byte("test6"), 0)
+
+	leader.Apply([]byte("test7"), 0)
+	future := leader.Apply([]byte("test8"), 0)
+
+	// Wait for the last future to apply
+	if err := future.Error(); err != nil {
+		c.FailNowf("[ERR] err: %v", err)
+	}
+
+	// Shutdown follower
+	if f := follower.Shutdown(); f.Error() != nil {
+		c.FailNowf("error shuting down follower: %v", f.Error())
+	}
+
+	// Try to restart the follower and make sure it does not fail with a LogNotFound error
+	_, trans := NewInmemTransport(follower.localAddr)
+	follower.logs = es.LogStore
+	conf := follower.config()
+	n, err := NewRaft(&conf, &MockFSM{}, follower.logs, follower.stable, follower.snapshots, trans)
+	if err != nil {
+		c.FailNowf("error restarting follower: %v", err)
+	}
+	n.Shutdown()
+}
 func TestRaft_ReloadConfig(t *testing.T) {
 	conf := inmemConfig(t)
 	c := MakeCluster(1, t, conf)


### PR DESCRIPTION
Original author was #430 
[FIXED] LogCache should not cache on StoreLogs error
LogCache was caching logs and then invoking store.StoreLogs().
However, if StoreLogs() fails to store, LogCache.Get() could still
return logs that had not been persisted into storage, which could
lead to a node failing to restart with a "log not found" panic.

This PR ensures that LogCache only cache logs if StoreLogs was
successful.

Resolves #429

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>