### PR TITLE
make TestRaft_RecoverCluster less flaky

### DIFF
--- a/raft_test.go
+++ b/raft_test.go
@@ -204,14 +204,14 @@ func TestRaft_RecoverCluster(t *testing.T) {
 			c.fsms[i] = r2.fsm.(*MockFSM)
 		}
 		c.FullyConnect()
-		time.Sleep(c.propagateTimeout)
+		time.Sleep(c.propagateTimeout * 3)
 
 		// Let things settle and make sure we recovered.
 		c.EnsureLeader(t, c.Leader().localAddr)
 		c.EnsureSame(t)
 		c.EnsureSamePeers(t)
 	}
-	for applies := 0; applies < 20; applies++ {
+	for applies := 0; applies < 10; applies++ {
 		t.Run(fmt.Sprintf("%d applies", applies), func(t *testing.T) {
 			runRecover(t, applies)
 		})

--- a/testing.go
+++ b/testing.go
@@ -234,8 +234,8 @@ func (c *cluster) Failf(format string, args ...interface{}) {
 // other goroutines created during the test. Calling FailNowf does not stop
 // those other goroutines.
 func (c *cluster) FailNowf(format string, args ...interface{}) {
-	c.logger.Error(fmt.Sprintf(format, args...))
-	c.t.FailNow()
+	c.t.Helper()
+	c.t.Fatalf(format, args...)
 }
 
 // Close shuts down the cluster and cleans up.
@@ -433,6 +433,7 @@ func (c *cluster) GetInState(s RaftState) []*Raft {
 
 // Leader waits for the cluster to elect a leader and stay in a stable state.
 func (c *cluster) Leader() *Raft {
+	c.t.Helper()
 	leaders := c.GetInState(Leader)
 	if len(leaders) != 1 {
 		c.FailNowf("expected one leader: %v", leaders)


### PR DESCRIPTION
@s-christoff @jsosulska and I paired on this.

The test seems to fail at the end when it's waiting on a leader. 

Increasing the number of peers seemed to make the test fail more often.
Increase the sleep seemed to make it fail much less.

We suspect that we could improve `EnsureLeader` to remove the need for a sleep by polling for a stable leader, but deferred that change for now since it seems this small change is working.
