### PR TITLE
Fix TestRaft_VerifyLeader

### DIFF
--- a/raft_test.go
+++ b/raft_test.go
@@ -1622,8 +1622,9 @@ func TestRaft_VerifyLeader_Fail(t *testing.T) {
 	c := MakeCluster(2, t, conf)
 	defer c.Close()
 
-	// Get the leader
 	leader := c.Leader()
+	// Remove the leader election notification from the channel buffer
+	<-leader.LeaderCh()
 
 	// Wait until we have a followers
 	followers := c.Followers()
@@ -1635,7 +1636,7 @@ func TestRaft_VerifyLeader_Fail(t *testing.T) {
 	// Wait for the leader to step down
 	select {
 	case v := <-leader.LeaderCh():
-		if !v {
+		if v {
 			t.Fatalf("expected the leader to step down")
 		}
 	case <-time.After(conf.HeartbeatTimeout * 3):

--- a/raft_test.go
+++ b/raft_test.go
@@ -1632,20 +1632,19 @@ func TestRaft_VerifyLeader_Fail(t *testing.T) {
 	follower := followers[0]
 	follower.setCurrentTerm(follower.getCurrentTerm() + 1)
 
-	// Verify we are leader
-	verify := leader.VerifyLeader()
-
 	// Wait for the leader to step down
 	select {
 	case v := <-leader.LeaderCh():
 		if !v {
-			break
+			t.Fatalf("expected the leader to step down")
 		}
 	case <-time.After(conf.HeartbeatTimeout * 3):
 		c.FailNowf("timeout waiting for leader to step down")
 	}
 
-	// Should we just delete this?
+	// Verify we are leader
+	verify := leader.VerifyLeader()
+
 	if err := verify.Error(); err != ErrNotLeader && err != ErrLeadershipLost {
 		c.FailNowf("err: %v", err)
 	}

--- a/raft_test.go
+++ b/raft_test.go
@@ -1633,7 +1633,6 @@ func TestRaft_VerifyLeader_Fail(t *testing.T) {
 	follower.setCurrentTerm(follower.getCurrentTerm() + 1)
 
 	// Verify we are leader
-
 	verify := leader.VerifyLeader()
 
 	// Wait for the leader to step down


### PR DESCRIPTION
It looks like we are waiting for the leader to step down and verify there is no leader. 
This may be a great case to use the `LeaderCh` !
Opinions welcome :) 