### PR TITLE
testing: remove cluster.FailNowf

### DIFF
--- a/raft_test.go
+++ b/raft_test.go
@@ -28,31 +28,31 @@ func TestRaft_AfterShutdown(t *testing.T) {
 
 	// Everything should fail now
 	if f := raft.Apply(nil, 0); f.Error() != ErrRaftShutdown {
-		c.FailNowf("should be shutdown: %v", f.Error())
+		t.Fatalf("should be shutdown: %v", f.Error())
 	}
 
 	// TODO (slackpad) - Barrier, VerifyLeader, and GetConfiguration can get
 	// stuck if the buffered channel consumes the future but things are shut
 	// down so they never get processed.
 	if f := raft.AddVoter(ServerID("id"), ServerAddress("addr"), 0, 0); f.Error() != ErrRaftShutdown {
-		c.FailNowf("should be shutdown: %v", f.Error())
+		t.Fatalf("should be shutdown: %v", f.Error())
 	}
 	if f := raft.AddNonvoter(ServerID("id"), ServerAddress("addr"), 0, 0); f.Error() != ErrRaftShutdown {
-		c.FailNowf("should be shutdown: %v", f.Error())
+		t.Fatalf("should be shutdown: %v", f.Error())
 	}
 	if f := raft.RemoveServer(ServerID("id"), 0, 0); f.Error() != ErrRaftShutdown {
-		c.FailNowf("should be shutdown: %v", f.Error())
+		t.Fatalf("should be shutdown: %v", f.Error())
 	}
 	if f := raft.DemoteVoter(ServerID("id"), 0, 0); f.Error() != ErrRaftShutdown {
-		c.FailNowf("should be shutdown: %v", f.Error())
+		t.Fatalf("should be shutdown: %v", f.Error())
 	}
 	if f := raft.Snapshot(); f.Error() != ErrRaftShutdown {
-		c.FailNowf("should be shutdown: %v", f.Error())
+		t.Fatalf("should be shutdown: %v", f.Error())
 	}
 
 	// Should be idempotent
 	if f := raft.Shutdown(); f.Error() != nil {
-		c.FailNowf("shutdown should be idempotent")
+		t.Fatalf("shutdown should be idempotent")
 	}
 
 }
@@ -75,7 +75,7 @@ func TestRaft_LiveBootstrap(t *testing.T) {
 	// Bootstrap one of the nodes live.
 	boot := c.rafts[0].BootstrapCluster(configuration)
 	if err := boot.Error(); err != nil {
-		c.FailNowf("bootstrap err: %v", err)
+		t.Fatalf("bootstrap err: %v", err)
 	}
 
 	// Should be one leader.
@@ -86,14 +86,14 @@ func TestRaft_LiveBootstrap(t *testing.T) {
 	// Should be able to apply.
 	future := leader.Apply([]byte("test"), c.conf.CommitTimeout)
 	if err := future.Error(); err != nil {
-		c.FailNowf("apply err: %v", err)
+		t.Fatalf("apply err: %v", err)
 	}
 	c.WaitForReplication(1)
 
 	// Make sure the live bootstrap fails now that things are started up.
 	boot = c.rafts[0].BootstrapCluster(configuration)
 	if err := boot.Error(); err != ErrCantBootstrap {
-		c.FailNowf("bootstrap should have failed: %v", err)
+		t.Fatalf("bootstrap should have failed: %v", err)
 	}
 }
 
@@ -114,7 +114,7 @@ func TestRaft_RecoverCluster_NoState(t *testing.T) {
 	err := RecoverCluster(&cfg, &MockFSM{}, r.logs, r.stable,
 		r.snapshots, r.trans, configuration)
 	if err == nil || !strings.Contains(err.Error(), "no initial state") {
-		c.FailNowf("should have failed for no initial state: %v", err)
+		t.Fatalf("should have failed for no initial state: %v", err)
 	}
 }
 
@@ -135,21 +135,21 @@ func TestRaft_RecoverCluster(t *testing.T) {
 		for i := 0; i < applies; i++ {
 			future := leader.Apply([]byte(fmt.Sprintf("test%d", i)), 0)
 			if err = future.Error(); err != nil {
-				c.FailNowf("[ERR] apply err: %v", err)
+				t.Fatalf("[ERR] apply err: %v", err)
 			}
 		}
 
 		// Snap the configuration.
 		future := leader.GetConfiguration()
 		if err = future.Error(); err != nil {
-			c.FailNowf("[ERR] get configuration err: %v", err)
+			t.Fatalf("[ERR] get configuration err: %v", err)
 		}
 		configuration := future.Configuration()
 
 		// Shut down the cluster.
 		for _, sec := range c.rafts {
 			if err = sec.Shutdown().Error(); err != nil {
-				c.FailNowf("[ERR] shutdown err: %v", err)
+				t.Fatalf("[ERR] shutdown err: %v", err)
 			}
 		}
 
@@ -159,35 +159,35 @@ func TestRaft_RecoverCluster(t *testing.T) {
 			var before []*SnapshotMeta
 			before, err = r.snapshots.List()
 			if err != nil {
-				c.FailNowf("snapshot list err: %v", err)
+				t.Fatalf("snapshot list err: %v", err)
 			}
 			cfg := r.config()
 			if err = RecoverCluster(&cfg, &MockFSM{}, r.logs, r.stable,
 				r.snapshots, r.trans, configuration); err != nil {
-				c.FailNowf("recover err: %v", err)
+				t.Fatalf("recover err: %v", err)
 			}
 
 			// Make sure the recovery looks right.
 			var after []*SnapshotMeta
 			after, err = r.snapshots.List()
 			if err != nil {
-				c.FailNowf("snapshot list err: %v", err)
+				t.Fatalf("snapshot list err: %v", err)
 			}
 			if len(after) != len(before)+1 {
-				c.FailNowf("expected a new snapshot, %d vs. %d", len(before), len(after))
+				t.Fatalf("expected a new snapshot, %d vs. %d", len(before), len(after))
 			}
 			var first uint64
 			first, err = r.logs.FirstIndex()
 			if err != nil {
-				c.FailNowf("first log index err: %v", err)
+				t.Fatalf("first log index err: %v", err)
 			}
 			var last uint64
 			last, err = r.logs.LastIndex()
 			if err != nil {
-				c.FailNowf("last log index err: %v", err)
+				t.Fatalf("last log index err: %v", err)
 			}
 			if first != 0 || last != 0 {
-				c.FailNowf("expected empty logs, got %d/%d", first, last)
+				t.Fatalf("expected empty logs, got %d/%d", first, last)
 			}
 
 			// Fire up the recovered Raft instance. We have to patch
@@ -197,7 +197,7 @@ func TestRaft_RecoverCluster(t *testing.T) {
 			var r2 *Raft
 			r2, err = NewRaft(&cfg, &MockFSM{}, r.logs, r.stable, r.snapshots, trans)
 			if err != nil {
-				c.FailNowf("new raft err: %v", err)
+				t.Fatalf("new raft err: %v", err)
 			}
 			c.rafts[i] = r2
 			c.trans[i] = r2.trans.(*InmemTransport)
@@ -231,7 +231,7 @@ func TestRaft_HasExistingState(t *testing.T) {
 	var hasState bool
 	hasState, err = HasExistingState(c1.rafts[0].logs, c1.rafts[0].stable, c1.rafts[0].snapshots)
 	if err != nil || hasState {
-		c.FailNowf("should not have any existing state, %v", err)
+		t.Fatalf("should not have any existing state, %v", err)
 	}
 
 	// Merge clusters.
@@ -241,7 +241,7 @@ func TestRaft_HasExistingState(t *testing.T) {
 	// Join the new node in.
 	future := c.Leader().AddVoter(c1.rafts[0].localID, c1.rafts[0].localAddr, 0, 0)
 	if err = future.Error(); err != nil {
-		c.FailNowf("[ERR] err: %v", err)
+		t.Fatalf("[ERR] err: %v", err)
 	}
 
 	// Check the FSMs.
@@ -256,7 +256,7 @@ func TestRaft_HasExistingState(t *testing.T) {
 	// Make sure it's not clean.
 	hasState, err = HasExistingState(c1.rafts[0].logs, c1.rafts[0].stable, c1.rafts[0].snapshots)
 	if err != nil || !hasState {
-		c.FailNowf("should have some existing state, %v", err)
+		t.Fatalf("should have some existing state, %v", err)
 	}
 }
 
@@ -270,36 +270,36 @@ func TestRaft_SingleNode(t *testing.T) {
 	select {
 	case v := <-raft.LeaderCh():
 		if !v {
-			c.FailNowf("should become leader")
+			t.Fatalf("should become leader")
 		}
 	case <-time.After(conf.HeartbeatTimeout * 3):
-		c.FailNowf("timeout becoming leader")
+		t.Fatalf("timeout becoming leader")
 	}
 
 	// Should be leader
 	if s := raft.State(); s != Leader {
-		c.FailNowf("expected leader: %v", s)
+		t.Fatalf("expected leader: %v", s)
 	}
 
 	// Should be able to apply
 	future := raft.Apply([]byte("test"), c.conf.HeartbeatTimeout)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Check the response
 	if future.Response().(int) != 1 {
-		c.FailNowf("bad response: %v", future.Response())
+		t.Fatalf("bad response: %v", future.Response())
 	}
 
 	// Check the index
 	if idx := future.Index(); idx == 0 {
-		c.FailNowf("bad index: %d", idx)
+		t.Fatalf("bad index: %d", idx)
 	}
 
 	// Check that it is applied to the FSM
 	if len(getMockFSM(c.fsms[0]).logs) != 1 {
-		c.FailNowf("did not apply to FSM!")
+		t.Fatalf("did not apply to FSM!")
 	}
 }
 
@@ -316,7 +316,7 @@ func TestRaft_TripleNode(t *testing.T) {
 	// Should be able to apply
 	future := leader.Apply([]byte("test"), c.conf.CommitTimeout)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	c.WaitForReplication(1)
 }
@@ -333,7 +333,7 @@ func TestRaft_LeaderFail(t *testing.T) {
 	// Should be able to apply
 	future := leader.Apply([]byte("test"), c.conf.CommitTimeout)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	c.WaitForReplication(1)
 
@@ -353,12 +353,12 @@ func TestRaft_LeaderFail(t *testing.T) {
 		}
 	}
 	if newLead == nil {
-		c.FailNowf("expected new leader")
+		t.Fatalf("expected new leader")
 	}
 
 	// Ensure the term is greater
 	if newLead.getCurrentTerm() <= leaderTerm {
-		c.FailNowf("expected newer term! %d %d (%v, %v)", newLead.getCurrentTerm(), leaderTerm, newLead, leader)
+		t.Fatalf("expected newer term! %d %d (%v, %v)", newLead.getCurrentTerm(), leaderTerm, newLead, leader)
 	}
 
 	// Apply should work not work on old leader
@@ -369,7 +369,7 @@ func TestRaft_LeaderFail(t *testing.T) {
 
 	// Future2 should work
 	if err := future2.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Reconnect the networks
@@ -378,7 +378,7 @@ func TestRaft_LeaderFail(t *testing.T) {
 
 	// Future1 should fail
 	if err := future1.Error(); err != ErrLeadershipLost && err != ErrNotLeader {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Wait for log replication
@@ -389,13 +389,13 @@ func TestRaft_LeaderFail(t *testing.T) {
 		fsm := getMockFSM(fsmRaw)
 		fsm.Lock()
 		if len(fsm.logs) != 2 {
-			c.FailNowf("did not apply both to FSM! %v", fsm.logs)
+			t.Fatalf("did not apply both to FSM! %v", fsm.logs)
 		}
 		if bytes.Compare(fsm.logs[0], []byte("test")) != 0 {
-			c.FailNowf("first entry should be 'test'")
+			t.Fatalf("first entry should be 'test'")
 		}
 		if bytes.Compare(fsm.logs[1], []byte("apply")) != 0 {
-			c.FailNowf("second entry should be 'apply'")
+			t.Fatalf("second entry should be 'apply'")
 		}
 		fsm.Unlock()
 	}
@@ -420,14 +420,14 @@ func TestRaft_BehindFollower(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	} else {
 		t.Logf("[INFO] Finished apply without behind follower")
 	}
 
 	// Check that we have a non zero last contact
 	if behind.LastContact().IsZero() {
-		c.FailNowf("expected previous contact")
+		t.Fatalf("expected previous contact")
 	}
 
 	// Reconnect the behind node
@@ -452,19 +452,19 @@ func TestRaft_ApplyNonLeader(t *testing.T) {
 	// Try to apply to them
 	followers := c.GetInState(Follower)
 	if len(followers) != 2 {
-		c.FailNowf("Expected 2 followers")
+		t.Fatalf("Expected 2 followers")
 	}
 	follower := followers[0]
 
 	// Try to apply
 	future := follower.Apply([]byte("test"), c.conf.CommitTimeout)
 	if future.Error() != ErrNotLeader {
-		c.FailNowf("should not apply on follower")
+		t.Fatalf("should not apply on follower")
 	}
 
 	// Should be cached
 	if future.Error() != ErrNotLeader {
-		c.FailNowf("should not apply on follower")
+		t.Fatalf("should not apply on follower")
 	}
 }
 
@@ -506,13 +506,13 @@ func TestRaft_ApplyConcurrent(t *testing.T) {
 	select {
 	case <-doneCh:
 	case <-time.After(c.longstopTimeout):
-		c.FailNowf("timeout")
+		t.Fatalf("timeout")
 	}
 
 	// If anything failed up to this point then bail now, rather than do a
 	// confusing compare.
 	if t.Failed() {
-		c.FailNowf("One or more of the apply operations failed")
+		t.Fatalf("One or more of the apply operations failed")
 	}
 
 	// Check the FSMs
@@ -556,7 +556,7 @@ func TestRaft_ApplyConcurrent_Timeout(t *testing.T) {
 		}
 		c.WaitEvent(nil, c.propagateTimeout)
 	}
-	c.FailNowf("Timeout waiting to detect apply timeouts")
+	t.Fatalf("Timeout waiting to detect apply timeouts")
 }
 
 func TestRaft_JoinNode(t *testing.T) {
@@ -574,7 +574,7 @@ func TestRaft_JoinNode(t *testing.T) {
 	// Join the new node in
 	future := c.Leader().AddVoter(c1.rafts[0].localID, c1.rafts[0].localAddr, 0, 0)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Ensure one leader
@@ -620,12 +620,12 @@ func TestRaft_JoinNode_ConfigStore(t *testing.T) {
 	// Join the new node in
 	future := c.Leader().AddVoter(c1.rafts[0].localID, c1.rafts[0].localAddr, 0, 0)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	// Join the new node in
 	future = c.Leader().AddVoter(c2.rafts[0].localID, c2.rafts[0].localAddr, 0, 0)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Ensure one leader
@@ -641,16 +641,16 @@ func TestRaft_JoinNode_ConfigStore(t *testing.T) {
 	for _, fsmRaw := range c.fsms {
 		fsm := getMockFSM(fsmRaw)
 		if len(fsm.configurations) != 3 {
-			c.FailNowf("unexpected number of configuration changes: %d", len(fsm.configurations))
+			t.Fatalf("unexpected number of configuration changes: %d", len(fsm.configurations))
 		}
 		if len(fsm.configurations[0].Servers) != 1 {
-			c.FailNowf("unexpected number of servers in config change: %v", fsm.configurations[0].Servers)
+			t.Fatalf("unexpected number of servers in config change: %v", fsm.configurations[0].Servers)
 		}
 		if len(fsm.configurations[1].Servers) != 2 {
-			c.FailNowf("unexpected number of servers in config change: %v", fsm.configurations[1].Servers)
+			t.Fatalf("unexpected number of servers in config change: %v", fsm.configurations[1].Servers)
 		}
 		if len(fsm.configurations[2].Servers) != 3 {
-			c.FailNowf("unexpected number of servers in config change: %v", fsm.configurations[2].Servers)
+			t.Fatalf("unexpected number of servers in config change: %v", fsm.configurations[2].Servers)
 		}
 	}
 
@@ -672,14 +672,14 @@ func TestRaft_RemoveFollower(t *testing.T) {
 		followers = c.GetInState(Follower)
 	}
 	if len(followers) != 2 {
-		c.FailNowf("expected two followers: %v", followers)
+		t.Fatalf("expected two followers: %v", followers)
 	}
 
 	// Remove a follower
 	follower := followers[0]
 	future := leader.RemoveServer(follower.localID, 0, 0)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Wait a while
@@ -687,10 +687,10 @@ func TestRaft_RemoveFollower(t *testing.T) {
 
 	// Other nodes should have fewer peers
 	if configuration := c.getConfiguration(leader); len(configuration.Servers) != 2 {
-		c.FailNowf("too many peers")
+		t.Fatalf("too many peers")
 	}
 	if configuration := c.getConfiguration(followers[1]); len(configuration.Servers) != 2 {
-		c.FailNowf("too many peers")
+		t.Fatalf("too many peers")
 	}
 }
 
@@ -710,7 +710,7 @@ func TestRaft_RemoveLeader(t *testing.T) {
 		followers = c.GetInState(Follower)
 	}
 	if len(followers) != 2 {
-		c.FailNowf("expected two followers: %v", followers)
+		t.Fatalf("expected two followers: %v", followers)
 	}
 
 	// Remove the leader
@@ -718,7 +718,7 @@ func TestRaft_RemoveLeader(t *testing.T) {
 
 	// Wait for the future to complete
 	if f.Error() != nil {
-		c.FailNowf("RemoveServer() returned error %v", f.Error())
+		t.Fatalf("RemoveServer() returned error %v", f.Error())
 	}
 
 	// Wait a bit for log application
@@ -728,17 +728,17 @@ func TestRaft_RemoveLeader(t *testing.T) {
 	time.Sleep(c.propagateTimeout)
 	newLeader := c.Leader()
 	if newLeader == leader {
-		c.FailNowf("removed leader is still leader")
+		t.Fatalf("removed leader is still leader")
 	}
 
 	// Other nodes should have fewer peers
 	if configuration := c.getConfiguration(newLeader); len(configuration.Servers) != 2 {
-		c.FailNowf("wrong number of peers %d", len(configuration.Servers))
+		t.Fatalf("wrong number of peers %d", len(configuration.Servers))
 	}
 
 	// Old leader should be shutdown
 	if leader.State() != Shutdown {
-		c.FailNowf("old leader should be shutdown")
+		t.Fatalf("old leader should be shutdown")
 	}
 }
 
@@ -758,13 +758,13 @@ func TestRaft_RemoveLeader_NoShutdown(t *testing.T) {
 		if i == 80 {
 			removeFuture := leader.RemoveServer(leader.localID, 0, 0)
 			if err := removeFuture.Error(); err != nil {
-				c.FailNowf("err: %v, remove leader failed", err)
+				t.Fatalf("err: %v, remove leader failed", err)
 			}
 		}
 		future := leader.Apply([]byte{i}, 0)
 		if i > 80 {
 			if err := future.Error(); err == nil || err != ErrNotLeader {
-				c.FailNowf("err: %v, future entries should fail", err)
+				t.Fatalf("err: %v, future entries should fail", err)
 			}
 		}
 	}
@@ -781,24 +781,24 @@ func TestRaft_RemoveLeader_NoShutdown(t *testing.T) {
 	// Other nodes should have pulled the leader.
 	configuration := c.getConfiguration(newLeader)
 	if len(configuration.Servers) != 2 {
-		c.FailNowf("too many peers")
+		t.Fatalf("too many peers")
 	}
 	if hasVote(configuration, leader.localID) {
-		c.FailNowf("old leader should no longer have a vote")
+		t.Fatalf("old leader should no longer have a vote")
 	}
 
 	// Old leader should be a follower.
 	if leader.State() != Follower {
-		c.FailNowf("leader should be follower")
+		t.Fatalf("leader should be follower")
 	}
 
 	// Old leader should not include itself in its peers.
 	configuration = c.getConfiguration(leader)
 	if len(configuration.Servers) != 2 {
-		c.FailNowf("too many peers")
+		t.Fatalf("too many peers")
 	}
 	if hasVote(configuration, leader.localID) {
-		c.FailNowf("old leader should no longer have a vote")
+		t.Fatalf("old leader should no longer have a vote")
 	}
 
 	// Other nodes should have the same state
@@ -824,21 +824,21 @@ func TestRaft_RemoveFollower_SplitCluster(t *testing.T) {
 		numServers = len(configuration.Servers)
 	}
 	if numServers != 4 {
-		c.FailNowf("Leader should have 4 servers, got %d", numServers)
+		t.Fatalf("Leader should have 4 servers, got %d", numServers)
 	}
 	c.EnsureSamePeers(t)
 
 	// Isolate two of the followers.
 	followers := c.Followers()
 	if len(followers) != 3 {
-		c.FailNowf("Expected 3 followers, got %d", len(followers))
+		t.Fatalf("Expected 3 followers, got %d", len(followers))
 	}
 	c.Partition([]ServerAddress{followers[0].localAddr, followers[1].localAddr})
 
 	// Try to remove the remaining follower that was left with the leader.
 	future := leader.RemoveServer(followers[2].localID, 0, 0)
 	if err := future.Error(); err == nil {
-		c.FailNowf("Should not have been able to make peer change")
+		t.Fatalf("Should not have been able to make peer change")
 	}
 }
 
@@ -855,7 +855,7 @@ func TestRaft_AddKnownPeer(t *testing.T) {
 	configReq.init()
 	leader.configurationsCh <- configReq
 	if err := configReq.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	startingConfig := configReq.configurations.committed
 	startingConfigIdx := configReq.configurations.committedIndex
@@ -863,21 +863,21 @@ func TestRaft_AddKnownPeer(t *testing.T) {
 	// Add a follower
 	future := leader.AddVoter(followers[0].localID, followers[0].localAddr, 0, 0)
 	if err := future.Error(); err != nil {
-		c.FailNowf("AddVoter() err: %v", err)
+		t.Fatalf("AddVoter() err: %v", err)
 	}
 	configReq = &configurationsFuture{}
 	configReq.init()
 	leader.configurationsCh <- configReq
 	if err := configReq.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	newConfig := configReq.configurations.committed
 	newConfigIdx := configReq.configurations.committedIndex
 	if newConfigIdx <= startingConfigIdx {
-		c.FailNowf("AddVoter should have written a new config entry, but configurations.commitedIndex still %d", newConfigIdx)
+		t.Fatalf("AddVoter should have written a new config entry, but configurations.commitedIndex still %d", newConfigIdx)
 	}
 	if !reflect.DeepEqual(newConfig, startingConfig) {
-		c.FailNowf("[ERR} AddVoter with existing peer shouldn't have changed config, was %#v, but now %#v", startingConfig, newConfig)
+		t.Fatalf("[ERR} AddVoter with existing peer shouldn't have changed config, was %#v, but now %#v", startingConfig, newConfig)
 	}
 }
 
@@ -892,7 +892,7 @@ func TestRaft_RemoveUnknownPeer(t *testing.T) {
 	configReq.init()
 	leader.configurationsCh <- configReq
 	if err := configReq.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	startingConfig := configReq.configurations.committed
 	startingConfigIdx := configReq.configurations.committedIndex
@@ -902,21 +902,21 @@ func TestRaft_RemoveUnknownPeer(t *testing.T) {
 
 	// nothing to do, should be a new config entry that's the same as before
 	if err := future.Error(); err != nil {
-		c.FailNowf("RemoveServer() err: %v", err)
+		t.Fatalf("RemoveServer() err: %v", err)
 	}
 	configReq = &configurationsFuture{}
 	configReq.init()
 	leader.configurationsCh <- configReq
 	if err := configReq.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	newConfig := configReq.configurations.committed
 	newConfigIdx := configReq.configurations.committedIndex
 	if newConfigIdx <= startingConfigIdx {
-		c.FailNowf("RemoveServer should have written a new config entry, but configurations.commitedIndex still %d", newConfigIdx)
+		t.Fatalf("RemoveServer should have written a new config entry, but configurations.commitedIndex still %d", newConfigIdx)
 	}
 	if !reflect.DeepEqual(newConfig, startingConfig) {
-		c.FailNowf("[ERR} RemoveServer with unknown peer shouldn't of changed config, was %#v, but now %#v", startingConfig, newConfig)
+		t.Fatalf("[ERR} RemoveServer with unknown peer shouldn't of changed config, was %#v, but now %#v", startingConfig, newConfig)
 	}
 }
 
@@ -936,31 +936,31 @@ func TestRaft_SnapshotRestore(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Take a snapshot
 	snapFuture := leader.Snapshot()
 	if err := snapFuture.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Check for snapshot
 	snaps, _ := leader.snapshots.List()
 	if len(snaps) != 1 {
-		c.FailNowf("should have a snapshot")
+		t.Fatalf("should have a snapshot")
 	}
 	snap := snaps[0]
 
 	// Logs should be trimmed
 	if idx, _ := leader.logs.FirstIndex(); idx != snap.Index-conf.TrailingLogs+1 {
-		c.FailNowf("should trim logs to %d: but is %d", snap.Index-conf.TrailingLogs+1, idx)
+		t.Fatalf("should trim logs to %d: but is %d", snap.Index-conf.TrailingLogs+1, idx)
 	}
 
 	// Shutdown
 	shutdown := leader.Shutdown()
 	if err := shutdown.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Restart the Raft
@@ -970,13 +970,13 @@ func TestRaft_SnapshotRestore(t *testing.T) {
 	cfg := r.config()
 	r, err := NewRaft(&cfg, r.fsm, r.logs, r.stable, r.snapshots, trans2)
 	if err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	c.rafts[0] = r
 
 	// We should have restored from the snapshot!
 	if last := r.getLastApplied(); last != snap.Index {
-		c.FailNowf("bad last index: %d, expecting %d", last, snap.Index)
+		t.Fatalf("bad last index: %d, expecting %d", last, snap.Index)
 	}
 }
 
@@ -1001,19 +1001,19 @@ func TestRaft_NoRestoreOnStart(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Take a snapshot.
 	snapFuture := leader.Snapshot()
 	if err := snapFuture.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Shutdown.
 	shutdown := leader.Shutdown()
 	if err := shutdown.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	_, trans := NewInmemTransport(leader.localAddr)
@@ -1021,11 +1021,11 @@ func TestRaft_NoRestoreOnStart(t *testing.T) {
 	cfg := leader.config()
 	_, err := NewRaft(&cfg, newFSM, leader.logs, leader.stable, leader.snapshots, trans)
 	if err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	if len(newFSM.logs) != 0 {
-		c.FailNowf("expected empty FSM, got %v", newFSM)
+		t.Fatalf("expected empty FSM, got %v", newFSM)
 	}
 }
 
@@ -1047,19 +1047,19 @@ func TestRaft_SnapshotRestore_PeerChange(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err = future.Error(); err != nil {
-		c.FailNowf("[ERR] err: %v", err)
+		t.Fatalf("[ERR] err: %v", err)
 	}
 
 	// Take a snapshot.
 	snapFuture := leader.Snapshot()
 	if err = snapFuture.Error(); err != nil {
-		c.FailNowf("[ERR] err: %v", err)
+		t.Fatalf("[ERR] err: %v", err)
 	}
 
 	// Shutdown.
 	shutdown := leader.Shutdown()
 	if err = shutdown.Error(); err != nil {
-		c.FailNowf("[ERR] err: %v", err)
+		t.Fatalf("[ERR] err: %v", err)
 	}
 
 	// Make a separate cluster.
@@ -1070,7 +1070,7 @@ func TestRaft_SnapshotRestore_PeerChange(t *testing.T) {
 	for _, sec := range c.rafts {
 		if sec != leader {
 			if err = sec.Shutdown().Error(); err != nil {
-				c.FailNowf("[ERR] shutdown err: %v", err)
+				t.Fatalf("[ERR] shutdown err: %v", err)
 			}
 		}
 	}
@@ -1089,21 +1089,21 @@ func TestRaft_SnapshotRestore_PeerChange(t *testing.T) {
 	// Perform a manual recovery on the cluster.
 	base, err := ioutil.TempDir("", "")
 	if err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	defer os.RemoveAll(base)
 	peersFile := filepath.Join(base, "peers.json")
 	if err = ioutil.WriteFile(peersFile, content, 0666); err != nil {
-		c.FailNowf("[ERR] err: %v", err)
+		t.Fatalf("[ERR] err: %v", err)
 	}
 	configuration, err := ReadPeersJSON(peersFile)
 	if err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	cfg := r.config()
 	if err = RecoverCluster(&cfg, &MockFSM{}, r.logs, r.stable,
 		r.snapshots, r.trans, configuration); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Can't just reuse the old transport as it will be closed. We also start
@@ -1111,7 +1111,7 @@ func TestRaft_SnapshotRestore_PeerChange(t *testing.T) {
 	_, trans := NewInmemTransport(r.localAddr)
 	r, err = NewRaft(&cfg, &MockFSM{}, r.logs, r.stable, r.snapshots, trans)
 	if err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	c.rafts[0] = r
 	c2.rafts = append(c2.rafts, r)
@@ -1128,7 +1128,7 @@ func TestRaft_SnapshotRestore_PeerChange(t *testing.T) {
 	// We should have restored from the snapshot! Note that there's one
 	// index bump from the noop the leader tees up when it takes over.
 	if last := r.getLastApplied(); last != 103 {
-		c.FailNowf("bad last: %v", last)
+		t.Fatalf("bad last: %v", last)
 	}
 
 	// Check the peers.
@@ -1153,7 +1153,7 @@ func TestRaft_AutoSnapshot(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Wait for a snapshot to happen
@@ -1161,7 +1161,7 @@ func TestRaft_AutoSnapshot(t *testing.T) {
 
 	// Check for snapshot
 	if snaps, _ := leader.snapshots.List(); len(snaps) == 0 {
-		c.FailNowf("should have a snapshot")
+		t.Fatalf("should have a snapshot")
 	}
 }
 
@@ -1177,7 +1177,7 @@ func TestRaft_UserSnapshot(t *testing.T) {
 	leader := c.Leader()
 	if userSnapshotErrorsOnNoData {
 		if err := leader.Snapshot().Error(); err != ErrNothingNewToSnapshot {
-			c.FailNowf("Request for Snapshot failed: %v", err)
+			t.Fatalf("Request for Snapshot failed: %v", err)
 		}
 	}
 
@@ -1187,17 +1187,17 @@ func TestRaft_UserSnapshot(t *testing.T) {
 		future = leader.Apply([]byte(fmt.Sprintf("test %d", i)), 0)
 	}
 	if err := future.Error(); err != nil {
-		c.FailNowf("Error Apply new log entries: %v", err)
+		t.Fatalf("Error Apply new log entries: %v", err)
 	}
 
 	// Now we should be able to ask for a snapshot without getting an error.
 	if err := leader.Snapshot().Error(); err != nil {
-		c.FailNowf("Request for Snapshot failed: %v", err)
+		t.Fatalf("Request for Snapshot failed: %v", err)
 	}
 
 	// Check for snapshot
 	if snaps, _ := leader.snapshots.List(); len(snaps) == 0 {
-		c.FailNowf("should have a snapshot")
+		t.Fatalf("should have a snapshot")
 	}
 }
 
@@ -1223,13 +1223,13 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 		future = leader.Apply([]byte(fmt.Sprintf("test %d", i)), 0)
 	}
 	if err := future.Error(); err != nil {
-		c.FailNowf("Error Apply new log entries: %v", err)
+		t.Fatalf("Error Apply new log entries: %v", err)
 	}
 
 	// Take a snapshot.
 	snap := leader.Snapshot()
 	if err := snap.Error(); err != nil {
-		c.FailNowf("Request for Snapshot failed: %v", err)
+		t.Fatalf("Request for Snapshot failed: %v", err)
 	}
 
 	// Commit some more things.
@@ -1237,7 +1237,7 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 		future = leader.Apply([]byte(fmt.Sprintf("test %d", i)), 0)
 	}
 	if err := future.Error(); err != nil {
-		c.FailNowf("Error Apply new log entries: %v", err)
+		t.Fatalf("Error Apply new log entries: %v", err)
 	}
 
 	// Get the last index before the restore.
@@ -1247,11 +1247,11 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 	meta, reader, err := snap.Open()
 	meta.Index += offset
 	if err != nil {
-		c.FailNowf("Snapshot open failed: %v", err)
+		t.Fatalf("Snapshot open failed: %v", err)
 	}
 	defer reader.Close()
 	if err := leader.Restore(meta, reader, 5*time.Second); err != nil {
-		c.FailNowf("Restore failed: %v", err)
+		t.Fatalf("Restore failed: %v", err)
 	}
 
 	// Make sure the index was updated correctly. We add 2 because we burn
@@ -1265,7 +1265,7 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 	}
 	lastIndex := leader.getLastIndex()
 	if lastIndex != expected {
-		c.FailNowf("Index was not updated correctly: %d vs. %d", lastIndex, expected)
+		t.Fatalf("Index was not updated correctly: %d vs. %d", lastIndex, expected)
 	}
 
 	// Ensure all the logs are the same and that we have everything that was
@@ -1275,12 +1275,12 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 	fsm := getMockFSM(c.fsms[0])
 	fsm.Lock()
 	if len(fsm.logs) != 10 {
-		c.FailNowf("Log length bad: %d", len(fsm.logs))
+		t.Fatalf("Log length bad: %d", len(fsm.logs))
 	}
 	for i, entry := range fsm.logs {
 		expected := []byte(fmt.Sprintf("test %d", i))
 		if bytes.Compare(entry, expected) != 0 {
-			c.FailNowf("Log entry bad: %v", entry)
+			t.Fatalf("Log entry bad: %v", entry)
 		}
 	}
 	fsm.Unlock()
@@ -1290,7 +1290,7 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 		future = leader.Apply([]byte(fmt.Sprintf("test %d", i)), 0)
 	}
 	if err := future.Error(); err != nil {
-		c.FailNowf("Error Apply new log entries: %v", err)
+		t.Fatalf("Error Apply new log entries: %v", err)
 	}
 	c.EnsureSame(t)
 }
@@ -1335,7 +1335,7 @@ func TestRaft_SendSnapshotFollower(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	} else {
 		t.Logf("[INFO] Finished apply without behind follower")
 	}
@@ -1345,7 +1345,7 @@ func TestRaft_SendSnapshotFollower(t *testing.T) {
 		future = r.Snapshot()
 		// the disconnected node will have nothing to snapshot, so that's expected
 		if err := future.Error(); err != nil && err != ErrNothingNewToSnapshot {
-			c.FailNowf("err: %v", err)
+			t.Fatalf("err: %v", err)
 		}
 	}
 
@@ -1377,7 +1377,7 @@ func TestRaft_SendSnapshotAndLogsFollower(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	} else {
 		t.Logf("[INFO] Finished apply without behind follower")
 	}
@@ -1387,7 +1387,7 @@ func TestRaft_SendSnapshotAndLogsFollower(t *testing.T) {
 		future = r.Snapshot()
 		// the disconnected node will have nothing to snapshot, so that's expected
 		if err := future.Error(); err != nil && err != ErrNothingNewToSnapshot {
-			c.FailNowf("err: %v", err)
+			t.Fatalf("err: %v", err)
 		}
 	}
 
@@ -1398,7 +1398,7 @@ func TestRaft_SendSnapshotAndLogsFollower(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	} else {
 		t.Logf("[INFO] Finished apply without behind follower")
 	}
@@ -1428,23 +1428,23 @@ func TestRaft_ReJoinFollower(t *testing.T) {
 		followers = c.GetInState(Follower)
 	}
 	if len(followers) != 2 {
-		c.FailNowf("expected two followers: %v", followers)
+		t.Fatalf("expected two followers: %v", followers)
 	}
 
 	// Remove a follower.
 	follower := followers[0]
 	future := leader.RemoveServer(follower.localID, 0, 0)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Other nodes should have fewer peers.
 	time.Sleep(c.propagateTimeout)
 	if configuration := c.getConfiguration(leader); len(configuration.Servers) != 2 {
-		c.FailNowf("too many peers: %v", configuration)
+		t.Fatalf("too many peers: %v", configuration)
 	}
 	if configuration := c.getConfiguration(followers[1]); len(configuration.Servers) != 2 {
-		c.FailNowf("too many peers: %v", configuration)
+		t.Fatalf("too many peers: %v", configuration)
 	}
 
 	// Get the leader. We can't use the normal stability checker here because
@@ -1458,7 +1458,7 @@ func TestRaft_ReJoinFollower(t *testing.T) {
 		leaders, _ = c.pollState(Leader)
 	}
 	if len(leaders) != 1 {
-		c.FailNowf("expected a leader")
+		t.Fatalf("expected a leader")
 	}
 	leader = leaders[0]
 
@@ -1467,7 +1467,7 @@ func TestRaft_ReJoinFollower(t *testing.T) {
 	// to take place. We should eventually re-stabilize.
 	future = leader.AddVoter(follower.localID, follower.localAddr, 0, 0)
 	if err := future.Error(); err != nil && err != ErrLeadershipLost {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// We should level back up to the proper number of peers. We add a
@@ -1475,15 +1475,15 @@ func TestRaft_ReJoinFollower(t *testing.T) {
 	// there's a solid leader.
 	leader = c.Leader()
 	if configuration := c.getConfiguration(leader); len(configuration.Servers) != 3 {
-		c.FailNowf("missing peers: %v", configuration)
+		t.Fatalf("missing peers: %v", configuration)
 	}
 	if configuration := c.getConfiguration(followers[1]); len(configuration.Servers) != 3 {
-		c.FailNowf("missing peers: %v", configuration)
+		t.Fatalf("missing peers: %v", configuration)
 	}
 
 	// Should be a follower now.
 	if follower.State() != Follower {
-		c.FailNowf("bad state: %v", follower.State())
+		t.Fatalf("bad state: %v", follower.State())
 	}
 }
 
@@ -1504,7 +1504,7 @@ func TestRaft_LeaderLeaseExpire(t *testing.T) {
 		followers = c.GetInState(Follower)
 	}
 	if len(followers) != 1 {
-		c.FailNowf("expected a followers: %v", followers)
+		t.Fatalf("expected a followers: %v", followers)
 	}
 
 	// Disconnect the follower now
@@ -1522,18 +1522,18 @@ LOOP:
 				break LOOP
 			}
 		case <-timeout:
-			c.FailNowf("timeout stepping down as leader")
+			t.Fatalf("timeout stepping down as leader")
 		}
 	}
 
 	// Ensure the last contact of the leader is non-zero
 	if leader.LastContact().IsZero() {
-		c.FailNowf("expected non-zero contact time")
+		t.Fatalf("expected non-zero contact time")
 	}
 
 	// Should be no leaders
 	if len(c.GetInState(Leader)) != 0 {
-		c.FailNowf("expected step down")
+		t.Fatalf("expected step down")
 	}
 
 	// Verify no further contact
@@ -1542,15 +1542,15 @@ LOOP:
 
 	// Check that last contact has not changed
 	if last != follower.LastContact() {
-		c.FailNowf("unexpected further contact")
+		t.Fatalf("unexpected further contact")
 	}
 
 	// Ensure both have cleared their leader
 	if l := leader.Leader(); l != "" {
-		c.FailNowf("bad: %v", l)
+		t.Fatalf("bad: %v", l)
 	}
 	if l := follower.Leader(); l != "" {
-		c.FailNowf("bad: %v", l)
+		t.Fatalf("bad: %v", l)
 	}
 }
 
@@ -1572,13 +1572,13 @@ func TestRaft_Barrier(t *testing.T) {
 
 	// Wait for the barrier future to apply
 	if err := barrier.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Ensure all the logs are the same
 	c.EnsureSame(t)
 	if len(getMockFSM(c.fsms[0]).logs) != 100 {
-		c.FailNowf(fmt.Sprintf("Bad log length: %d", len(getMockFSM(c.fsms[0]).logs)))
+		t.Fatalf(fmt.Sprintf("Bad log length: %d", len(getMockFSM(c.fsms[0]).logs)))
 	}
 }
 
@@ -1595,7 +1595,7 @@ func TestRaft_VerifyLeader(t *testing.T) {
 
 	// Wait for the verify to apply
 	if err := verify.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 }
 
@@ -1612,7 +1612,7 @@ func TestRaft_VerifyLeader_Single(t *testing.T) {
 
 	// Wait for the verify to apply
 	if err := verify.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 }
 
@@ -1637,12 +1637,12 @@ func TestRaft_VerifyLeader_Fail(t *testing.T) {
 
 	// Wait for the leader to step down
 	if err := verify.Error(); err != ErrNotLeader && err != ErrLeadershipLost {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Ensure the known leader is cleared
 	if l := leader.Leader(); l != "" {
-		c.FailNowf("bad: %v", l)
+		t.Fatalf("bad: %v", l)
 	}
 }
 
@@ -1663,7 +1663,7 @@ func TestRaft_VerifyLeader_PartialConnect(t *testing.T) {
 		followers = c.GetInState(Follower)
 	}
 	if len(followers) != 2 {
-		c.FailNowf("expected two followers but got: %v", followers)
+		t.Fatalf("expected two followers but got: %v", followers)
 	}
 
 	// Force partial disconnect
@@ -1676,7 +1676,7 @@ func TestRaft_VerifyLeader_PartialConnect(t *testing.T) {
 
 	// Wait for the leader to step down
 	if err := verify.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 }
 
@@ -1691,10 +1691,10 @@ func TestRaft_NotifyCh(t *testing.T) {
 	select {
 	case v := <-ch:
 		if !v {
-			c.FailNowf("should become leader")
+			t.Fatalf("should become leader")
 		}
 	case <-time.After(conf.HeartbeatTimeout * 8):
-		c.FailNowf("timeout becoming leader")
+		t.Fatalf("timeout becoming leader")
 	}
 
 	// Close the cluster
@@ -1704,10 +1704,10 @@ func TestRaft_NotifyCh(t *testing.T) {
 	select {
 	case v := <-ch:
 		if v {
-			c.FailNowf("should step down as leader")
+			t.Fatalf("should step down as leader")
 		}
 	case <-time.After(conf.HeartbeatTimeout * 6):
-		c.FailNowf("timeout on step down as leader")
+		t.Fatalf("timeout on step down as leader")
 	}
 }
 
@@ -1729,28 +1729,28 @@ func TestRaft_Voting(t *testing.T) {
 	// a follower that thinks there's a leader should vote for that leader.
 	var resp RequestVoteResponse
 	if err := ldrT.RequestVote(followers[0].localID, followers[0].localAddr, &reqVote, &resp); err != nil {
-		c.FailNowf("RequestVote RPC failed %v", err)
+		t.Fatalf("RequestVote RPC failed %v", err)
 	}
 	if !resp.Granted {
-		c.FailNowf("expected vote to be granted, but wasn't %+v", resp)
+		t.Fatalf("expected vote to be granted, but wasn't %+v", resp)
 	}
 	// a follower that thinks there's a leader shouldn't vote for a different candidate
 	reqVote.Candidate = ldrT.EncodePeer(followers[0].localID, followers[0].localAddr)
 	if err := ldrT.RequestVote(followers[1].localID, followers[1].localAddr, &reqVote, &resp); err != nil {
-		c.FailNowf("RequestVote RPC failed %v", err)
+		t.Fatalf("RequestVote RPC failed %v", err)
 	}
 	if resp.Granted {
-		c.FailNowf("expected vote not to be granted, but was %+v", resp)
+		t.Fatalf("expected vote not to be granted, but was %+v", resp)
 	}
 	// a follower that thinks there's a leader, but the request has the leadership transfer flag, should
 	// vote for a different candidate
 	reqVote.LeadershipTransfer = true
 	reqVote.Candidate = ldrT.EncodePeer(followers[0].localID, followers[0].localAddr)
 	if err := ldrT.RequestVote(followers[1].localID, followers[1].localAddr, &reqVote, &resp); err != nil {
-		c.FailNowf("RequestVote RPC failed %v", err)
+		t.Fatalf("RequestVote RPC failed %v", err)
 	}
 	if !resp.Granted {
-		c.FailNowf("expected vote to be granted, but wasn't %+v", resp)
+		t.Fatalf("expected vote to be granted, but wasn't %+v", resp)
 	}
 }
 
@@ -1775,14 +1775,14 @@ func TestRaft_ProtocolVersion_RejectRPC(t *testing.T) {
 	var resp RequestVoteResponse
 	err := ldrT.RequestVote(followers[0].localID, followers[0].localAddr, &reqVote, &resp)
 	if err == nil || !strings.Contains(err.Error(), "protocol version") {
-		c.FailNowf("expected RPC to get rejected: %v", err)
+		t.Fatalf("expected RPC to get rejected: %v", err)
 	}
 
 	// Reject a message that's too old.
 	reqVote.RPCHeader.ProtocolVersion = followers[0].protocolVersion - 2
 	err = ldrT.RequestVote(followers[0].localID, followers[0].localAddr, &reqVote, &resp)
 	if err == nil || !strings.Contains(err.Error(), "protocol version") {
-		c.FailNowf("expected RPC to get rejected: %v", err)
+		t.Fatalf("expected RPC to get rejected: %v", err)
 	}
 }
 
@@ -1806,16 +1806,16 @@ func TestRaft_ProtocolVersion_Upgrade_1_2(t *testing.T) {
 	// protocol.
 	future := c.Leader().AddNonvoter(c1.rafts[0].localID, c1.rafts[0].localAddr, 0, 1*time.Second)
 	if err := future.Error(); err != ErrUnsupportedProtocol {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 	future = c.Leader().DemoteVoter(c1.rafts[0].localID, 0, 1*time.Second)
 	if err := future.Error(); err != ErrUnsupportedProtocol {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Now do the join using the old address-based API.
 	if future := c.Leader().AddPeer(c1.rafts[0].localAddr); future.Error() != nil {
-		c.FailNowf("err: %v", future.Error())
+		t.Fatalf("err: %v", future.Error())
 	}
 
 	// Sanity check the cluster.
@@ -1825,7 +1825,7 @@ func TestRaft_ProtocolVersion_Upgrade_1_2(t *testing.T) {
 
 	// Now do the remove using the old address-based API.
 	if future := c.Leader().RemovePeer(c1.rafts[0].localAddr); future.Error() != nil {
-		c.FailNowf("err: %v", future.Error())
+		t.Fatalf("err: %v", future.Error())
 	}
 }
 
@@ -1849,7 +1849,7 @@ func TestRaft_ProtocolVersion_Upgrade_2_3(t *testing.T) {
 	// Use the new ID-based API to add the server with its ID.
 	future := c.Leader().AddVoter(c1.rafts[0].localID, c1.rafts[0].localAddr, 0, 1*time.Second)
 	if err := future.Error(); err != nil {
-		c.FailNowf("err: %v", err)
+		t.Fatalf("err: %v", err)
 	}
 
 	// Sanity check the cluster.
@@ -1859,7 +1859,7 @@ func TestRaft_ProtocolVersion_Upgrade_2_3(t *testing.T) {
 
 	// Remove an old server using the old address-based API.
 	if future := c.Leader().RemovePeer(oldAddr); future.Error() != nil {
-		c.FailNowf("err: %v", future.Error())
+		t.Fatalf("err: %v", future.Error())
 	}
 }
 
@@ -2151,7 +2151,7 @@ func TestRaft_GetConfigurationNoBootstrap(t *testing.T) {
 	// Should be able to apply
 	future := leader.Apply([]byte("test"), c.conf.CommitTimeout)
 	if err := future.Error(); err != nil {
-		c.FailNowf("[ERR] err: %v", err)
+		t.Fatalf("[ERR] err: %v", err)
 	}
 	c.WaitForReplication(1)
 
@@ -2194,7 +2194,7 @@ func TestRaft_CacheLogWithStoreError(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		future := leader.Apply([]byte(fmt.Sprintf("test%d", i)), 0)
 		if err := future.Error(); err != nil {
-			c.FailNowf("[ERR] err: %v", err)
+			t.Fatalf("[ERR] err: %v", err)
 		}
 	}
 
@@ -2207,12 +2207,12 @@ func TestRaft_CacheLogWithStoreError(t *testing.T) {
 
 	// Wait for the last future to apply
 	if err := future.Error(); err != nil {
-		c.FailNowf("[ERR] err: %v", err)
+		t.Fatalf("[ERR] err: %v", err)
 	}
 
 	// Shutdown follower
 	if f := follower.Shutdown(); f.Error() != nil {
-		c.FailNowf("error shuting down follower: %v", f.Error())
+		t.Fatalf("error shuting down follower: %v", f.Error())
 	}
 
 	// Try to restart the follower and make sure it does not fail with a LogNotFound error
@@ -2221,7 +2221,7 @@ func TestRaft_CacheLogWithStoreError(t *testing.T) {
 	conf := follower.config()
 	n, err := NewRaft(&conf, &MockFSM{}, follower.logs, follower.stable, follower.snapshots, trans)
 	if err != nil {
-		c.FailNowf("error restarting follower: %v", err)
+		t.Fatalf("error restarting follower: %v", err)
 	}
 	n.Shutdown()
 }

--- a/testing.go
+++ b/testing.go
@@ -255,7 +255,7 @@ func (c *cluster) Close() {
 
 	for _, f := range futures {
 		if err := f.Error(); err != nil {
-			c.FailNowf("shutdown future err: %v", err)
+			c.t.Fatalf("shutdown future err: %v", err)
 		}
 	}
 
@@ -316,7 +316,7 @@ CHECK:
 			c.t.FailNow()
 
 		case <-limitCh:
-			c.FailNowf("timeout waiting for replication")
+			c.t.Fatalf("timeout waiting for replication")
 
 		case <-ch:
 			for _, fsmRaw := range c.fsms {
@@ -414,14 +414,14 @@ func (c *cluster) GetInState(s RaftState) []*Raft {
 			c.t.FailNow()
 
 		case <-limitCh:
-			c.FailNowf("timeout waiting for stable %s state", s)
+			c.t.Fatalf("timeout waiting for stable %s state", s)
 
 		case <-eventCh:
 			c.logger.Debug("resetting stability timeout")
 
 		case t, ok := <-timer.C:
 			if !ok {
-				c.FailNowf("timer channel errored")
+				c.t.Fatalf("timer channel errored")
 			}
 
 			c.logger.Info(fmt.Sprintf("stable state for %s reached at %s (%d nodes), %s from start of poll, %s from cluster start. Timeout at %s, %s after stability",
@@ -436,7 +436,7 @@ func (c *cluster) Leader() *Raft {
 	c.t.Helper()
 	leaders := c.GetInState(Leader)
 	if len(leaders) != 1 {
-		c.FailNowf("expected one leader: %v", leaders)
+		c.t.Fatalf("expected one leader: %v", leaders)
 	}
 	return leaders[0]
 }
@@ -447,7 +447,7 @@ func (c *cluster) Followers() []*Raft {
 	expFollowers := len(c.rafts) - 1
 	followers := c.GetInState(Follower)
 	if len(followers) != expFollowers {
-		c.FailNowf("timeout waiting for %d followers (followers are %v)", expFollowers, followers)
+		c.t.Fatalf("timeout waiting for %d followers (followers are %v)", expFollowers, followers)
 	}
 	return followers
 }
@@ -543,7 +543,7 @@ func (c *cluster) EnsureLeader(t *testing.T, expect ServerAddress) {
 		}
 	}
 	if fail {
-		c.FailNowf("at least one peer has the wrong notion of leader")
+		t.Fatalf("at least one peer has the wrong notion of leader")
 	}
 }
 
@@ -564,7 +564,7 @@ CHECK:
 		if len(first.logs) != len(fsm.logs) {
 			fsm.Unlock()
 			if time.Now().After(limit) {
-				c.FailNowf("FSM log length mismatch: %d %d",
+				t.Fatalf("FSM log length mismatch: %d %d",
 					len(first.logs), len(fsm.logs))
 			} else {
 				goto WAIT
@@ -575,7 +575,7 @@ CHECK:
 			if bytes.Compare(first.logs[idx], fsm.logs[idx]) != 0 {
 				fsm.Unlock()
 				if time.Now().After(limit) {
-					c.FailNowf("FSM log mismatch at index %d", idx)
+					t.Fatalf("FSM log mismatch at index %d", idx)
 				} else {
 					goto WAIT
 				}
@@ -584,7 +584,7 @@ CHECK:
 		if len(first.configurations) != len(fsm.configurations) {
 			fsm.Unlock()
 			if time.Now().After(limit) {
-				c.FailNowf("FSM configuration length mismatch: %d %d",
+				t.Fatalf("FSM configuration length mismatch: %d %d",
 					len(first.logs), len(fsm.logs))
 			} else {
 				goto WAIT
@@ -595,7 +595,7 @@ CHECK:
 			if !reflect.DeepEqual(first.configurations[idx], fsm.configurations[idx]) {
 				fsm.Unlock()
 				if time.Now().After(limit) {
-					c.FailNowf("FSM configuration mismatch at index %d: %v, %v", idx, first.configurations[idx], fsm.configurations[idx])
+					t.Fatalf("FSM configuration mismatch at index %d: %v, %v", idx, first.configurations[idx], fsm.configurations[idx])
 				} else {
 					goto WAIT
 				}
@@ -618,7 +618,7 @@ WAIT:
 func (c *cluster) getConfiguration(r *Raft) Configuration {
 	future := r.GetConfiguration()
 	if err := future.Error(); err != nil {
-		c.FailNowf("failed to get configuration: %v", err)
+		c.t.Fatalf("failed to get configuration: %v", err)
 		return Configuration{}
 	}
 
@@ -639,7 +639,7 @@ CHECK:
 		otherSet := c.getConfiguration(raft)
 		if !reflect.DeepEqual(peerSet, otherSet) {
 			if time.Now().After(limit) {
-				c.FailNowf("peer mismatch: %+v %+v", peerSet, otherSet)
+				t.Fatalf("peer mismatch: %+v %+v", peerSet, otherSet)
 			} else {
 				goto WAIT
 			}
@@ -692,7 +692,7 @@ func makeCluster(t *testing.T, opts *MakeClusterOpts) *cluster {
 	for i := 0; i < opts.Peers; i++ {
 		dir, err := ioutil.TempDir("", "raft")
 		if err != nil {
-			c.FailNowf("err: %v", err)
+			t.Fatalf("err: %v", err)
 		}
 
 		store := NewInmemStore()
@@ -747,18 +747,18 @@ func makeCluster(t *testing.T, opts *MakeClusterOpts) *cluster {
 		if opts.Bootstrap {
 			err := BootstrapCluster(peerConf, logs, store, snap, trans, configuration)
 			if err != nil {
-				c.FailNowf("BootstrapCluster failed: %v", err)
+				t.Fatalf("BootstrapCluster failed: %v", err)
 			}
 		}
 
 		raft, err := NewRaft(peerConf, c.fsms[i], logs, store, snap, trans)
 		if err != nil {
-			c.FailNowf("NewRaft failed: %v", err)
+			t.Fatalf("NewRaft failed: %v", err)
 		}
 
 		raft.RegisterObserver(NewObserver(c.observationCh, false, nil))
 		if err != nil {
-			c.FailNowf("RegisterObserver failed: %v", err)
+			t.Fatalf("RegisterObserver failed: %v", err)
 		}
 		c.rafts = append(c.rafts, raft)
 	}


### PR DESCRIPTION
This function was nothing but a wrapper around t.Fatalf. Wrapping
t.Fatalf is problematic for a number of reasons:

1. It makes tests less obvious. A reader can easily reason about what
   t.Fatalf is doing, but has to look up what c.FailNowf is supposed to
   be. Since it doesn't do anything other than call t.Fatalf this is an
   unnecessary distraction.
2. Fatalf may only be called from the main goroutine. It is easy to call
   c.FailNowf from some other goroutine without realizing that it is
   incorrect, and there was at least one case of this recently in the
   test suite.
3. The old message that was being printed by FailNowf was going through
   the logger, making it a lot more difficult to find the error that
   caused the test to fail.
4. It is really easy to misuse FailNowf because it uses the testing.T
   embedded in cluster. If this function is called from any subtest, it
   will report the message to the wrong test (the root test instead of
   the sub test).