### PR TITLE
Handle installSnapshot decodePeers error without a panic

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -319,11 +319,11 @@ func encodePeers(configuration Configuration, trans Transport) []byte {
 // decodePeers is used to deserialize an old list of peers into a Configuration.
 // This is here for backwards compatibility with old log entries and snapshots;
 // it should be removed eventually.
-func decodePeers(buf []byte, trans Transport) Configuration {
+func decodePeers(buf []byte, trans Transport) (Configuration, error) {
 	// Decode the buffer first.
 	var encPeers [][]byte
 	if err := decodeMsgPack(buf, &encPeers); err != nil {
-		panic(fmt.Errorf("failed to decode peers: %v", err))
+		return Configuration{}, fmt.Errorf("failed to decode peers: %v", err)
 	}
 
 	// Deserialize each peer.
@@ -333,13 +333,11 @@ func decodePeers(buf []byte, trans Transport) Configuration {
 		servers = append(servers, Server{
 			Suffrage: Voter,
 			ID:       ServerID(p),
-			Address:  ServerAddress(p),
+			Address:  p,
 		})
 	}
 
-	return Configuration{
-		Servers: servers,
-	}
+	return Configuration{Servers: servers}, nil
 }
 
 // EncodeConfiguration serializes a Configuration using MsgPack, or panics on

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var sampleConfiguration = Configuration{
@@ -300,7 +302,8 @@ func TestConfiguration_encodeDecodePeers(t *testing.T) {
 	buf := encodePeers(configuration, trans)
 
 	// Decode from old format, as if reading an old log entry.
-	decoded := decodePeers(buf, trans)
+	decoded, err := decodePeers(buf, trans)
+	require.NoError(t, err)
 	if !reflect.DeepEqual(configuration, decoded) {
 		t.Fatalf("mismatch %v %v", configuration, decoded)
 	}


### PR DESCRIPTION
`decodePeers` can be called by the `installSnapshot` RPC handler, which means that a panic can be caused by an external actor by sending malformed input. Instead handle the error and report it back via the RPC response. This prevents a panic and removes the possibility of an external actor being able to cause a raft peer to panic.

The new test would cause a panic before, and now it confirms the expected error is returned.