### PR TITLE
Observe resumed heartbeat after failures

### DIFF
--- a/observer.go
+++ b/observer.go
@@ -34,6 +34,11 @@ type FailedHeartbeatObservation struct {
 	LastContact time.Time
 }
 
+// ResumedHeartbeatObservation is sent when a node resumes to heartbeat with the leader following failures
+type ResumedHeartbeatObservation struct {
+	PeerID ServerID
+}
+
 // nextObserverId is used to provide a unique ID for each observer to aid in
 // deregistration.
 var nextObserverID uint64

--- a/replication.go
+++ b/replication.go
@@ -388,6 +388,9 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			case <-stopCh:
 			}
 		} else {
+			if failures > 0 {
+				r.observe(ResumedHeartbeatObservation{PeerID: s.peer.ID})
+			}
 			s.setLastContact()
 			failures = 0
 			labels := []metrics.Label{{Name: "peer_id", Value: string(s.peer.ID)}}


### PR DESCRIPTION
Currently there is no way to tell that a peer is once again functional after one or more heartbeat failures. This adds `ResumedHeartbeatObservation` for such cases.

This is very similar to https://github.com/hashicorp/raft/pull/405