### PR TITLE
Pre-vote campaign

### DIFF
--- a/api.go
+++ b/api.go
@@ -201,6 +201,10 @@ type Raft struct {
 	// leadershipTransferCh is used to start a leadership transfer from outside of
 	// the main thread.
 	leadershipTransferCh chan *leadershipTransferFuture
+
+	// PreVote enables a campaign algorithm to prevent leadership disruption
+	// during a network partion and a node attempts to rejoin the cluster.
+	preVote bool
 }
 
 // BootstrapCluster initializes a server's storage with the given cluster
@@ -522,6 +526,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	// Create Raft struct.
 	r := &Raft{
 		protocolVersion:       protocolVersion,
+		preVote:               conf.PreVote,
 		applyCh:               applyCh,
 		fsm:                   fsm,
 		fsmMutateCh:           make(chan interface{}, 128),

--- a/commands.go
+++ b/commands.go
@@ -89,6 +89,9 @@ type RequestVoteRequest struct {
 	// transfer. It is required for leadership transfer to work, because servers
 	// wouldn't vote otherwise if they are aware of an existing leader.
 	LeadershipTransfer bool
+
+	// Used to indicate if a pre-vote campaign is being requested.
+	PreVote bool
 }
 
 // GetRPCHeader - See WithRPCHeader.
@@ -110,6 +113,9 @@ type RequestVoteResponse struct {
 
 	// Is the vote granted.
 	Granted bool
+
+	// Used to indicate if a pre-vote campaign is being requested.
+	PreVote bool
 }
 
 // GetRPCHeader - See WithRPCHeader.

--- a/config.go
+++ b/config.go
@@ -86,13 +86,16 @@ import (
 //    this protocol version, along with their server ID. The remove/add cycle
 //    is required to populate their server ID. Note that removing must be done
 //    by ID, which will be the old server's address.
+// 4: Adds pre-voting campaigns. It is expected that each node will be swapped
+//    out and then pre-voting turned on once all nodes are aware of pre-voting
+//    flags.
 type ProtocolVersion int
 
 const (
 	// ProtocolVersionMin is the minimum protocol version
 	ProtocolVersionMin ProtocolVersion = 0
 	// ProtocolVersionMax is the maximum protocol version
-	ProtocolVersionMax = 3
+	ProtocolVersionMax = 4
 )
 
 // SnapshotVersion is the version of snapshots that this server can understand.
@@ -219,6 +222,10 @@ type Config struct {
 	// raft's configuration and index values.
 	NoSnapshotRestoreOnStart bool
 
+	// PreVote enables a campaign algorithm to prevent leadership disruption
+	// during a network partion and a node attempts to rejoin the cluster.
+	PreVote bool
+
 	// skipStartup allows NewRaft() to bypass all background work goroutines
 	skipStartup bool
 }
@@ -293,6 +300,7 @@ func DefaultConfig() *Config {
 		SnapshotThreshold:  8192,
 		LeaderLeaseTimeout: 500 * time.Millisecond,
 		LogLevel:           "DEBUG",
+		PreVote:            false,
 	}
 }
 

--- a/raft.go
+++ b/raft.go
@@ -1751,13 +1751,9 @@ func (r *Raft) electSelf(preVote bool) <-chan *voteResult {
 	// Create a response channel
 	respCh := make(chan *voteResult, len(r.configurations.latest.Servers))
 
-	// PreVote campaigns are sent on the next term.
-	term := r.getCurrentTerm() + 1
-	if preVote {
-		term += 1
-	}
 	// Increment the term
-	r.setCurrentTerm(term)
+	// PreVote campaigns are sent on the same term.
+	r.setCurrentTerm(r.getCurrentTerm() + 1)
 
 	// Construct the request
 	lastIdx, lastTerm := r.getLastEntry()

--- a/testing.go
+++ b/testing.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	userSnapshotErrorsOnNoData = true
+	usePreVotingCampaign       = false
 )
 
 // Return configurations optimized for in-memory
@@ -28,6 +29,7 @@ func inmemConfig(t *testing.T) *Config {
 	conf.LeaderLeaseTimeout = 50 * time.Millisecond
 	conf.CommitTimeout = 5 * time.Millisecond
 	conf.Logger = newTestLogger(t)
+	conf.PreVote = usePreVotingCampaign
 	return conf
 }
 
@@ -454,6 +456,12 @@ func (c *cluster) Leader() *Raft {
 // state.
 func (c *cluster) Followers() []*Raft {
 	expFollowers := len(c.rafts) - 1
+	return c.FollowersN(expFollowers)
+}
+
+// FollowersN waits for the cluster to have N-1 followers and stay in a stable
+// state.
+func (c *cluster) FollowersN(expFollowers int) []*Raft {
 	followers := c.GetInState(Follower)
 	if len(followers) != expFollowers {
 		c.t.Fatalf("timeout waiting for %d followers (followers are %v)", expFollowers, followers)


### PR DESCRIPTION
The following attempts to implement a pre-voting campaign optimization.

> One downside of Raft’s leader election algorithm is that a server that has been partitioned from the
cluster is likely to cause a disruption when it regains connectivity. When a server is partitioned, it
will not receive heartbeats. It will soon increment its term to start an election, although it won’t
be able to collect enough votes to become leader. When the server regains connectivity sometime
later, its larger term number will propagate to the rest of the cluster (either through the server’s
RequestVote requests or through its AppendEntries response). This will force the cluster leader to
step down, and a new election will have to take place to select a new leader. Fortunately, such events
are likely to be rare, and each will only cause one leader to step down.

