### PR TITLE
Add retract directive for v1.1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
   lint:
     executor:
       name: golang
-      version: "1.16"
+      version: "1.17"
     steps:
       - checkout
       - run: go mod download

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,19 @@ workflows:
     jobs:
       - lint
       - go-test:
-          name: test go1.15
-          version: "1.15"
-      - go-test:
           name: test go1.16
           version: "1.16"
       - go-test:
           name: test go1.16 32bit
           version: "1.16"
+          goarch: "386"
+          args: "" # remove -race
+      - go-test:
+          name: test go1.17
+          version: "1.17"
+      - go-test:
+          name: test go1.17 32bit
+          version: "1.17"
           goarch: "386"
           args: "" # remove -race
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ fault tolerance as well.
 
 ## Building
 
-If you wish to build raft you'll need Go version 1.2+ installed.
+If you wish to build raft you'll need Go version 1.16+ installed.
 
 Please check your installation with:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/raft
 
-go 1.12
+go 1.16
 
 retract v1.1.3 // Deleted original tag; module checksum may not be accurate.
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/raft
 
 go 1.12
 
+retract v1.1.3 // Deleted original tag; module checksum may not be accurate.
+
 require (
 	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878
 	github.com/hashicorp/go-hclog v0.9.1

--- a/testing_batch.go
+++ b/testing_batch.go
@@ -1,3 +1,4 @@
+//go:build batchtest
 // +build batchtest
 
 package raft


### PR DESCRIPTION
We had issues `go get`-ing raft@v1.1.3 due to checksum mismatch. It turns out we created tag v1.1.3, fetched it as a module, then deleted the tag and recreated it on GitHub, which violates the assumption that modules are immutable (once fetched from Go's checksum proxies).

This PR ensures that users will not accidentally add v1.1.3 as a dependency.