### PR TITLE
a NonVoter node should never be able to transition to a Candidate state

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -173,17 +173,6 @@ func hasVote(configuration Configuration, id ServerID) bool {
 	return false
 }
 
-// hasVote returns true if the server identified by 'id' is a Voter in the
-// provided Configuration.
-func inConfig(configuration Configuration, id ServerID) bool {
-	for _, server := range configuration.Servers {
-		if server.ID == id {
-			return true
-		}
-	}
-	return false
-}
-
 // checkConfiguration tests a cluster membership configuration for common
 // errors.
 func checkConfiguration(configuration Configuration) error {

--- a/raft.go
+++ b/raft.go
@@ -214,15 +214,13 @@ func (r *Raft) runFollower() {
 				}
 			} else {
 				metrics.IncrCounter([]string{"raft", "transition", "heartbeat_timeout"}, 1)
-				if inConfig(r.configurations.latest, r.localID) {
+				if hasVote(r.configurations.latest, r.localID) {
 					r.logger.Warn("heartbeat timeout reached, starting election", "last-leader", lastLeader)
 					r.setState(Candidate)
 					return
-				} else {
-					if !didWarn {
-						r.logger.Warn("heartbeat timeout reached, not part of stable configuration, not triggering a leader election")
-						didWarn = true
-					}
+				} else if !didWarn {
+					r.logger.Warn("heartbeat timeout reached, not part of stable configuration, not triggering a leader election")
+					didWarn = true
 				}
 			}
 

--- a/raft.go
+++ b/raft.go
@@ -219,7 +219,7 @@ func (r *Raft) runFollower() {
 					r.setState(Candidate)
 					return
 				} else if !didWarn {
-					r.logger.Warn("heartbeat timeout reached, not part of stable configuration, not triggering a leader election")
+					r.logger.Warn("heartbeat timeout reached, not part of a stable configuration or a non-voter, not triggering a leader election")
 					didWarn = true
 				}
 			}

--- a/raft_test.go
+++ b/raft_test.go
@@ -2371,19 +2371,12 @@ func TestRaft_runFollower_State_Transition(t *testing.T) {
 			tt.fields.conf.CommitTimeout = 5 * time.Millisecond
 			tt.fields.conf.SnapshotThreshold = 100
 			tt.fields.conf.TrailingLogs = 10
+			tt.fields.conf.skipStartup = true
 
 			// Create a raft instance and set the latest configuration
 			env1 := MakeRaft(t, tt.fields.conf, false)
-			env1.raft.configurations.latest.Servers = tt.fields.servers
-			env1.raft.configurations.latestIndex = 1
-			env1.raft.state = Follower
-
-			// stop the main raft loop `run`
-			close(env1.raft.shutdownCh)
-			// wait for the loop to stop
-			time.Sleep(tt.fields.conf.HeartbeatTimeout * 3)
-			// create a new shutdown channel to avoid `runFollower` return an error
-			env1.raft.shutdownCh = make(chan struct{})
+			env1.raft.setLatestConfiguration(Configuration{Servers: tt.fields.servers}, 1)
+			env1.raft.setState(Follower)
 
 			// run the follower loop exclusively
 			go env1.raft.runFollower()

--- a/raft_test.go
+++ b/raft_test.go
@@ -2345,3 +2345,54 @@ func TestRaft_InstallSnapshot_InvalidPeers(t *testing.T) {
 	require.Error(t, resp.Error)
 	require.Contains(t, resp.Error.Error(), "failed to decode peers")
 }
+
+func TestRaft_runFollower_State_Transition(t *testing.T) {
+	type fields struct {
+		conf     *Config
+		servers  []Server
+		serverID ServerID
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		expectedState RaftState
+	}{
+		{"NonVoter", fields{conf: DefaultConfig(), servers: []Server{{Nonvoter, "first", ""}}, serverID: "first"}, Follower},
+		{"Voter", fields{conf: DefaultConfig(), servers: []Server{{Voter, "first", ""}}, serverID: "first"}, Candidate},
+		{"Not in Config", fields{conf: DefaultConfig(), servers: []Server{{Voter, "second", ""}}, serverID: "first"}, Follower},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// set timeout to tests specific
+			tt.fields.conf.LocalID = tt.fields.serverID
+			tt.fields.conf.HeartbeatTimeout = 50 * time.Millisecond
+			tt.fields.conf.ElectionTimeout = 50 * time.Millisecond
+			tt.fields.conf.LeaderLeaseTimeout = 50 * time.Millisecond
+			tt.fields.conf.CommitTimeout = 5 * time.Millisecond
+			tt.fields.conf.SnapshotThreshold = 100
+			tt.fields.conf.TrailingLogs = 10
+
+			// Create a raft instance and set the latest configuration
+			env1 := MakeRaft(t, tt.fields.conf, false)
+			env1.raft.configurations.latest.Servers = tt.fields.servers
+			env1.raft.configurations.latestIndex = 1
+			env1.raft.state = Follower
+
+			// stop the main raft loop `run`
+			close(env1.raft.shutdownCh)
+			// wait for the loop to stop
+			time.Sleep(tt.fields.conf.HeartbeatTimeout * 3)
+			// create a new shutdown channel to avoid `runFollower` return an error
+			env1.raft.shutdownCh = make(chan struct{})
+
+			// run the follower loop exclusively
+			go env1.raft.runFollower()
+
+			// wait enough time to have HeartbeatTimeout
+			time.Sleep(tt.fields.conf.HeartbeatTimeout * 3)
+
+			// Check the follower loop set the right state
+			require.Equal(t, tt.expectedState, env1.raft.getState())
+		})
+	}
+}


### PR DESCRIPTION
This behaviour was observed in Consul for read-replicas nodes (which are raft nonVoters node). When the cluster is not stable (leader transition) there is a possibility to a nonVoter node to step up as leader (which is not supposed to happen)

@mkeeler and me where able to reproduce the behaviour of having a nonVoter node transition to a Candidate state, which is an indication that this node is possibly able to win an election. The test do the following steps:

1. Create a cluster with 3 Voters node and 1 nonVoter node and wait for stability
2. Remove one follower node to trigger a configuration update
3. after the leader send an `appendEntry` log to the nonVoter to update the latest configuration and before it send the `appendEntry` to commit the new configuration, partition the leader
4. Check that the nonVoter transition to a `Candidate` state

Unfortunately step 3 is very time sensitive and we were not able to come with a test that would consistently reproduce the issue but we were able to confirm that after the fix in this PR the issue could not be reproduced.

