### PR TITLE
Leadership transfer gaps

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -570,6 +570,10 @@ func (r *Raft) leaderLoop() {
 	// based on the current config value.
 	lease := time.After(r.config().LeaderLeaseTimeout)
 
+	// This would unset leadershipTransferInProgress
+	// in case it was set during the loop
+	defer func() { r.setLeadershipTransferInProgress(false) }()
+
 	for r.getState() == Leader {
 		select {
 		case rpc := <-r.rpcCh:
@@ -644,7 +648,7 @@ func (r *Raft) leaderLoop() {
 				doneCh <- fmt.Errorf("cannot find replication state for %v", id)
 				continue
 			}
-
+			r.setLeadershipTransferInProgress(true)
 			go r.leadershipTransfer(*id, *address, state, stopCh, doneCh)
 
 		case <-r.leaderState.commitCh:
@@ -846,10 +850,6 @@ func (r *Raft) leadershipTransfer(id ServerID, address ServerAddress, repl *foll
 		return
 	default:
 	}
-
-	// Step 1: set this field which stops this leader from responding to any client requests.
-	r.setLeadershipTransferInProgress(true)
-	defer func() { r.setLeadershipTransferInProgress(false) }()
 
 	for atomic.LoadUint64(&repl.nextIndex) <= r.getLastIndex() {
 		err := &deferError{}

--- a/raft.go
+++ b/raft.go
@@ -1304,7 +1304,7 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 
 	// Increase the term if we see a newer one, also transition to follower
 	// if we ever get an appendEntries call
-	if a.Term > r.getCurrentTerm() || r.getState() != Follower {
+	if a.Term > r.getCurrentTerm() || (r.getState() != Follower && !r.candidateFromLeadershipTransfer) {
 		// Ensure transition to follower
 		r.setState(Follower)
 		r.setCurrentTerm(a.Term)


### PR DESCRIPTION
This is the steps that a leadership transfer API call do:
- we select the closest follower (if node not provided)
- we wait for it to catch up (for at most electionTimeout)
- we trigger an RPC call to that follower and we flip it to a candidate 
- the new candidate start a new term and force the old leader to step down (because it has a newer term)

but when the new candidate send the vote request the old leader (which made the transition to a follower by that time) reject it because it has newer logs. `rejecting vote request since our last index is greater` which favour that same node to become a leader in a next term and we are back to square 1. 

There is 3 gaps that lead to that issue:
- When we start the leadership transfer the flag `LeadershipTransferInProgress` which avoid replication to happen while we are doing the transfer is set inside a go routine, which create a gap while the go routine is scheduled
- The same flag `LeadershipTransferInProgress` is unset at the end of the go routine, without a guarantee that the leader loop is done in the old leader
- When the new leader get a transfer request and get a replication request from the old leader (while the transfer is happening) it will force it to a follower state, which cancel the transfer.

This PR is to close those 3 gaps.