### PR TITLE
Snapshot restore progress

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -463,20 +462,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	}
 
 	// Ensure we have a LogOutput.
-	var logger hclog.Logger
-	if conf.Logger != nil {
-		logger = conf.Logger
-	} else {
-		if conf.LogOutput == nil {
-			conf.LogOutput = os.Stderr
-		}
-
-		logger = hclog.New(&hclog.LoggerOptions{
-			Name:   "raft",
-			Level:  hclog.LevelFromString(conf.LogLevel),
-			Output: conf.LogOutput,
-		})
-	}
+	logger := conf.getOrCreateLogger()
 
 	// Try to restore the current term.
 	currentTerm, err := stable.GetUint64(keyCurrentTerm)

--- a/api.go
+++ b/api.go
@@ -339,7 +339,7 @@ func RecoverCluster(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 			"size-in-bytes", snapshot.Size,
 		)
 		crc := newCountingReadCloser(source)
-		monitor := startSnapshotRestoreMonitor(snapLogger, crc, snapshot.Size)
+		monitor := startSnapshotRestoreMonitor(snapLogger, crc, snapshot.Size, false)
 		err = fsm.Restore(crc)
 		// Close the source after the restore has completed
 		source.Close()

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package raft
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -220,6 +221,21 @@ type Config struct {
 
 	// skipStartup allows NewRaft() to bypass all background work goroutines
 	skipStartup bool
+}
+
+func (conf *Config) getOrCreateLogger() hclog.Logger {
+	if conf.Logger != nil {
+		return conf.Logger
+	}
+	if conf.LogOutput == nil {
+		conf.LogOutput = os.Stderr
+	}
+
+	return hclog.New(&hclog.LoggerOptions{
+		Name:   "raft",
+		Level:  hclog.LevelFromString(conf.LogLevel),
+		Output: conf.LogOutput,
+	})
 }
 
 // ReloadableConfig is the subset of Config that may be reconfigured during

--- a/fsm.go
+++ b/fsm.go
@@ -254,7 +254,7 @@ func fsmRestoreAndMeasure(logger hclog.Logger, fsm FSM, source io.ReadCloser, sn
 
 	crc := newCountingReadCloser(source)
 
-	monitor := startSnapshotRestoreMonitor(logger, crc, snapshotSize)
+	monitor := startSnapshotRestoreMonitor(logger, crc, snapshotSize, false)
 	defer monitor.StopAndWait()
 
 	if err := fsm.Restore(crc); err != nil {

--- a/fsm.go
+++ b/fsm.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	hclog "github.com/hashicorp/go-hclog"
 )
 
 // FSM is implemented by clients to make use of the replicated log.
@@ -184,8 +185,15 @@ func (r *Raft) runFSM() {
 		}
 		defer source.Close()
 
+		snapLogger := r.logger.With(
+			"id", req.ID,
+			"last-index", meta.Index,
+			"last-term", meta.Term,
+			"size-in-bytes", meta.Size,
+		)
+
 		// Attempt to restore
-		if err := fsmRestoreAndMeasure(r.fsm, source); err != nil {
+		if err := fsmRestoreAndMeasure(snapLogger, r.fsm, source, meta.Size); err != nil {
 			req.respond(fmt.Errorf("failed to restore snapshot %v: %v", req.ID, err))
 			return
 		}
@@ -241,7 +249,7 @@ func (r *Raft) runFSM() {
 // fsmRestoreAndMeasure wraps the Restore call on an FSM to consistently measure
 // and report timing metrics. The caller is still responsible for calling Close
 // on the source in all cases.
-func fsmRestoreAndMeasure(fsm FSM, source io.ReadCloser) error {
+func fsmRestoreAndMeasure(logger hclog.Logger, fsm FSM, source io.ReadCloser, snapshotSize int64) error {
 	start := time.Now()
 	if err := fsm.Restore(source); err != nil {
 		return err

--- a/progress.go
+++ b/progress.go
@@ -87,36 +87,6 @@ func (m *snapshotRestoreMonitor) StopAndWait() {
 	})
 }
 
-func reportProgress(
-	ctx context.Context,
-	interval time.Duration,
-	reportOnceFn func(last bool),
-) <-chan struct{} {
-	done := make(chan struct{})
-
-	go func() {
-		defer func() {
-			reportOnceFn(true)
-			close(done)
-		}()
-
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-			}
-
-			reportOnceFn(false)
-		}
-	}()
-
-	return done
-}
-
 type CountingReader interface {
 	io.Reader
 	Count() int64

--- a/progress.go
+++ b/progress.go
@@ -1,0 +1,143 @@
+package raft
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+const (
+	snapshotRestoreMonitorInterval = 10 * time.Second
+)
+
+type snapshotRestoreMonitor struct {
+	logger hclog.Logger
+	cr     CountingReader
+	size   int64
+
+	once   sync.Once
+	cancel func()
+	doneCh chan struct{}
+}
+
+func startSnapshotRestoreMonitor(logger hclog.Logger, cr CountingReader, size int64) *snapshotRestoreMonitor {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	m := &snapshotRestoreMonitor{
+		logger: logger,
+		cr:     cr,
+		size:   size,
+		cancel: cancel,
+		doneCh: make(chan struct{}),
+	}
+	go m.run(ctx)
+	return m
+}
+
+func (m *snapshotRestoreMonitor) run(ctx context.Context) {
+	defer close(m.doneCh)
+
+	ticker := time.NewTicker(snapshotRestoreMonitorInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.runOnce()
+		}
+	}
+}
+
+func (m *snapshotRestoreMonitor) runOnce() {
+	readBytes := m.cr.Count()
+	pct := float64(100*readBytes) / float64(m.size)
+
+	m.logger.Info("snapshot restoration progress",
+		"read-bytes", readBytes,
+		"percent-complete", hclog.Fmt("%0.2f%%", pct),
+	)
+}
+
+func (m *snapshotRestoreMonitor) StopAndWait() {
+	m.once.Do(func() {
+		m.cancel()
+		<-m.doneCh
+	})
+}
+
+func reportProgress(
+	ctx context.Context,
+	interval time.Duration,
+	reportOnceFn func(last bool),
+) <-chan struct{} {
+	done := make(chan struct{})
+
+	go func() {
+		defer func() {
+			reportOnceFn(true)
+			close(done)
+		}()
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			reportOnceFn(false)
+		}
+	}()
+
+	return done
+}
+
+type CountingReader interface {
+	io.Reader
+	Count() int64
+}
+
+type countingReader struct {
+	reader io.Reader
+
+	mu    sync.Mutex
+	bytes int64
+}
+
+func (r *countingReader) Read(p []byte) (n int, err error) {
+	n, err = r.reader.Read(p)
+	r.mu.Lock()
+	r.bytes += int64(n)
+	r.mu.Unlock()
+	return n, err
+}
+
+func (r *countingReader) Count() int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.bytes
+}
+
+func newCountingReader(r io.Reader) *countingReader {
+	return &countingReader{reader: r}
+}
+
+type countingReadCloser struct {
+	*countingReader
+	io.Closer
+}
+
+func newCountingReadCloser(rc io.ReadCloser) *countingReadCloser {
+	return &countingReadCloser{
+		countingReader: newCountingReader(rc),
+		Closer:         rc,
+	}
+}


### PR DESCRIPTION
When restoring a snapshot (on startup, installed from the leader, or during recovery) the logs are extremely terse. There are typically bookend messages indicating that a restore is going to happen, and that it is complete, but there's a big dead space in the middle.

For small snapshots this is probably fine, but for larger multi-GB snapshots this can stretch out and can be unnerving as an operator to know if it's stuck or still making progress.

This PR adjusts the logging to indicate a simple progress log message every 10s about overall completion in bytes-consumed.

Example of it in use while loading a large snapshot:

```
2022-02-09T17:26:17.050-0600 [INFO]  agent.server.snapshot: creating new snapshot: path=data/raft/snapshots/600-1900000-1444444444444.tmp
2022-02-09T17:26:19.602-0600 [INFO]  agent.server.raft: snapshot network transfer progress: read-bytes=1610612736 percent-complete=100.00%
2022-02-09T17:26:20.307-0600 [INFO]  agent.server.raft: copied to local snapshot: bytes=1610612736
2022-02-09T17:26:27.816-0600 [INFO]  agent: Synced node info
2022-02-09T17:26:31.746-0600 [INFO]  agent.server.raft: snapshot restore progress: id=600-1900000-1444444444444 last-index=1900000 last-term=600 size-in-bytes=1610612736 read-bytes=133680854 percent-complete=8.30%
2022-02-09T17:26:41.746-0600 [INFO]  agent.server.raft: snapshot restore progress: id=600-1900000-1444444444444 last-index=1900000 last-term=600 size-in-bytes=1610612736 read-bytes=212278758 percent-complete=13.18%
2022-02-09T17:26:51.746-0600 [INFO]  agent.server.raft: snapshot restore progress: id=600-1900000-1444444444444 last-index=1900000 last-term=600 size-in-bytes=1610612736 read-bytes=1293483088 percent-complete=80.31%
2022-02-09T17:26:56.361-0600 [INFO]  agent.server.raft: Installed remote snapshot
```

TODO: need to figure out a test