### PR TITLE
a NonVoter node should never try to bootstrap

### DIFF
--- a/api.go
+++ b/api.go
@@ -36,6 +36,10 @@ var (
 	// follower or candidate node.
 	ErrNotLeader = errors.New("node is not the leader")
 
+	// ErrNotVoter is returned when an operation can't be completed on a
+	// non-voter node.
+	ErrNotVoter = errors.New("node is not a voter")
+
 	// ErrLeadershipLost is returned when a leader fails to commit a log entry
 	// because it's been deposed in the process.
 	ErrLeadershipLost = errors.New("leadership lost while committing log")

--- a/raft.go
+++ b/raft.go
@@ -233,6 +233,11 @@ func (r *Raft) runFollower() {
 // the Raft object's member BootstrapCluster for more details. This must only be
 // called on the main thread, and only makes sense in the follower state.
 func (r *Raft) liveBootstrap(configuration Configuration) error {
+	if !hasVote(configuration, r.localID) {
+		// Reject this operation since we are not a voter
+		return ErrNotVoter
+	}
+
 	// Use the pre-init API to make the static updates.
 	cfg := r.config()
 	err := BootstrapCluster(&cfg, r.logs, r.stable, r.snapshots, r.trans, configuration)


### PR DESCRIPTION
This is a follow-up to #483

TODO:

- [x] add a test (likely inspired by consul's `TestServer_Expect_NonVoters` in some way since that's how i noticed the bug)