### PR TITLE
Cap maximum grpc wait time when heartbeating to heartbeatTimeout/2

### DIFF
--- a/raft_test.go
+++ b/raft_test.go
@@ -2644,8 +2644,8 @@ func TestRaft_VoteNotGranted_WhenNodeNotInCluster(t *testing.T) {
 func TestRaft_FollowerRemovalNoElection(t *testing.T) {
 	// Make a cluster
 	inmemConf := inmemConfig(t)
-	inmemConf.HeartbeatTimeout = 500 * time.Millisecond
-	inmemConf.ElectionTimeout = 500 * time.Millisecond
+	inmemConf.HeartbeatTimeout = 100 * time.Millisecond
+	inmemConf.ElectionTimeout = 100 * time.Millisecond
 	c := MakeCluster(3, t, inmemConf)
 
 	defer c.Close()
@@ -2677,7 +2677,6 @@ func TestRaft_FollowerRemovalNoElection(t *testing.T) {
 	if f := follower.Shutdown(); f.Error() != nil {
 		t.Fatalf("error shuting down follower: %v", f.Error())
 	}
-	time.Sleep(3 * time.Second)
 
 	_, trans := NewInmemTransport(follower.localAddr)
 	conf := follower.config()
@@ -2690,7 +2689,7 @@ func TestRaft_FollowerRemovalNoElection(t *testing.T) {
 	c.fsms[i] = n.fsm.(*MockFSM)
 	c.FullyConnect()
 	// There should be no re-election during this sleep
-	time.Sleep(2 * time.Second)
+	time.Sleep(250 * time.Millisecond)
 
 	// Let things settle and make sure we recovered.
 	c.EnsureLeader(t, leader.localAddr)

--- a/replication.go
+++ b/replication.go
@@ -407,7 +407,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			failures++
 			select {
 			case <-time.After(cappedExponentialBackoff(failureWait, failures, maxFailureScale,
-				r.config().HeartbeatTimeout/2)):
+				r.config().HeartbeatTimeout)):
 			case <-stopCh:
 				return
 			}

--- a/replication.go
+++ b/replication.go
@@ -402,7 +402,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 
 		start := time.Now()
 		if err := r.trans.AppendEntries(peer.ID, peer.Address, &req, &resp); err != nil {
-			nextBackoffTime := cappedExponentialBackoff(failureWait, s.failures, maxFailureScale, r.config().HeartbeatTimeout/2)
+			nextBackoffTime := cappedExponentialBackoff(failureWait, failures, maxFailureScale, r.config().HeartbeatTimeout/2)
 			r.logger.Error("failed to heartbeat to", "peer", peer.Address, "backoff time",
 				nextBackoffTime, "error", err)
 			r.observe(FailedHeartbeatObservation{PeerID: peer.ID, LastContact: s.LastContact()})

--- a/replication.go
+++ b/replication.go
@@ -406,8 +406,10 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			r.observe(FailedHeartbeatObservation{PeerID: peer.ID, LastContact: s.LastContact()})
 			failures++
 			select {
-			case <-time.After(backoff(failureWait, failures, maxFailureScale)):
+			case <-time.After(cappedExponentialBackoff(failureWait, failures, maxFailureScale,
+				r.config().HeartbeatTimeout/2)):
 			case <-stopCh:
+				return
 			}
 		} else {
 			if failures > 0 {

--- a/replication.go
+++ b/replication.go
@@ -406,8 +406,8 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			r.observe(FailedHeartbeatObservation{PeerID: peer.ID, LastContact: s.LastContact()})
 			failures++
 			select {
-			case <-time.After(cappedExponentialBackoff(failureWait, failures, maxFailureScale,
-				r.config().HeartbeatTimeout) / 2):
+			// case <-time.After(backoff(failureWait, s.failures, maxFailureScale)):
+			case <-time.After(cappedExponentialBackoff(failureWait, s.failures, maxFailureScale, DefaultConfig().HeartbeatTimeout)):
 			case <-stopCh:
 				return
 			}

--- a/replication.go
+++ b/replication.go
@@ -407,7 +407,7 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			failures++
 			select {
 			case <-time.After(cappedExponentialBackoff(failureWait, failures, maxFailureScale,
-				r.config().HeartbeatTimeout)):
+				r.config().HeartbeatTimeout) / 2):
 			case <-stopCh:
 				return
 			}

--- a/replication.go
+++ b/replication.go
@@ -408,7 +408,6 @@ func (r *Raft) heartbeat(s *followerReplication, stopCh chan struct{}) {
 			r.observe(FailedHeartbeatObservation{PeerID: peer.ID, LastContact: s.LastContact()})
 			failures++
 			select {
-			// case <-time.After(backoff(failureWait, s.failures, maxFailureScale)):
 			case <-time.After(nextBackoffTime):
 			case <-stopCh:
 				return

--- a/util.go
+++ b/util.go
@@ -144,6 +144,20 @@ func backoff(base time.Duration, round, limit uint64) time.Duration {
 	return base
 }
 
+// cappedExponentialBackoff computes the exponential backoff with an adjustable
+// cap on the max timeout.
+func cappedExponentialBackoff(base time.Duration, round, limit uint64, cap time.Duration) time.Duration {
+	power := min(round, limit)
+	for power > 2 {
+		if base > cap {
+			return base
+		}
+		base *= 2
+		power--
+	}
+	return base
+}
+
 // Needed for sorting []uint64, used to determine commitment
 type uint64Slice []uint64
 

--- a/util.go
+++ b/util.go
@@ -150,7 +150,7 @@ func cappedExponentialBackoff(base time.Duration, round, limit uint64, cap time.
 	power := min(round, limit)
 	for power > 2 {
 		if base > cap {
-			return base
+			return cap
 		}
 		base *= 2
 		power--


### PR DESCRIPTION
This PR aims to resolve https://hashicorp.atlassian.net/browse/VAULT-5310 , and the associated GH vault issue https://github.com/hashicorp/vault/issues/14153. 

Context: Currently, if the a follower is shut down for some amount of time, the leader cannot heartbeat to it and does an exponential backoff. When the follower restarts, the leader waits for longer than election_timeout to send a heartbeat to it, thus the follower starts an election and increases its term, which causes leadership to change. 