### PR TITLE
Fix a breaking change introduced in #477 and released in raft `v1.3.7`

### DIFF
--- a/observer.go
+++ b/observer.go
@@ -19,6 +19,8 @@ type Observation struct {
 
 // LeaderObservation is used for the data when leadership changes.
 type LeaderObservation struct {
+	// DEPRECATED The LeaderAddr field should now be used
+	Leader     ServerAddress
 	LeaderAddr ServerAddress
 	LeaderID   ServerID
 }

--- a/raft.go
+++ b/raft.go
@@ -101,7 +101,7 @@ func (r *Raft) setLeader(leaderAddr ServerAddress, leaderID ServerID) {
 	r.leaderID = leaderID
 	r.leaderLock.Unlock()
 	if oldLeaderAddr != leaderAddr || oldLeaderID != leaderID {
-		r.observe(LeaderObservation{LeaderAddr: leaderAddr, LeaderID: leaderID})
+		r.observe(LeaderObservation{Leader: leaderAddr, LeaderAddr: leaderAddr, LeaderID: leaderID})
 	}
 }
 


### PR DESCRIPTION
The `LeaderObservation` exported a `Leader` field, that field was replaced by `LeaderObservation` in #477, which represent a breaking change.
This PR reintroduce the `Leader` field and mark it as DEPRECATED.