### PR TITLE
Ensure Vault can access the underlying snapshotInstaller.

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -119,12 +119,28 @@ func newCountingReader(r io.Reader) *countingReader {
 
 type countingReadCloser struct {
 	*countingReader
-	io.Closer
+	readCloser io.ReadCloser
 }
 
 func newCountingReadCloser(rc io.ReadCloser) *countingReadCloser {
 	return &countingReadCloser{
 		countingReader: newCountingReader(rc),
-		Closer:         rc,
+		readCloser:     rc,
 	}
 }
+
+func (c countingReadCloser) Close() error {
+	return c.readCloser.Close()
+}
+
+func (c countingReadCloser) WrappedReadCloser() io.ReadCloser {
+	return c.readCloser
+}
+
+// ReadCloserWrapper allows access to an underlying ReadCloser from a wrapper.
+type ReadCloserWrapper interface {
+	io.ReadCloser
+	WrappedReadCloser() io.ReadCloser
+}
+
+var _ ReadCloserWrapper = &countingReadCloser{}


### PR DESCRIPTION
This code: https://github.com/hashicorp/vault/blob/main/physical/raft/fsm.go#L785
is broken since #490.  To allow Vault to upgrade to a current Raft release, I'm introducing a new interface that exposes the underlying ReadCloser clients passed in for a restore.