### PR TITLE
Export SkipStartup + add raft.Raft.Start()

### DIFF
--- a/api.go
+++ b/api.go
@@ -430,7 +430,7 @@ func RecoverCluster(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 // has identical behavior to Raft.GetConfiguration.
 func GetConfiguration(conf *Config, fsm FSM, logs LogStore, stable StableStore,
 	snaps SnapshotStore, trans Transport) (Configuration, error) {
-	conf.skipStartup = true
+	conf.SkipStartup = true
 	r, err := NewRaft(conf, fsm, logs, stable, snaps, trans)
 	if err != nil {
 		return Configuration{}, err
@@ -594,14 +594,18 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 	// to be called concurrently with a blocking RPC.
 	trans.SetHeartbeatHandler(r.processHeartbeat)
 
-	if conf.skipStartup {
+	if conf.SkipStartup {
 		return r, nil
 	}
-	// Start the background work.
+	r.Start()
+	return r, nil
+}
+
+// Start the background work.
+func (r *Raft) Start() {
 	r.goFunc(r.run)
 	r.goFunc(r.runFSM)
 	r.goFunc(r.runSnapshots)
-	return r, nil
 }
 
 // restoreSnapshot attempts to restore the latest snapshots, and fails if none

--- a/config.go
+++ b/config.go
@@ -219,8 +219,8 @@ type Config struct {
 	// raft's configuration and index values.
 	NoSnapshotRestoreOnStart bool
 
-	// skipStartup allows NewRaft() to bypass all background work goroutines
-	skipStartup bool
+	// SkipStartup allows NewRaft() to bypass all background work goroutines
+	SkipStartup bool
 }
 
 func (conf *Config) getOrCreateLogger() hclog.Logger {

--- a/raft_test.go
+++ b/raft_test.go
@@ -2822,7 +2822,7 @@ func TestRaft_runFollower_State_Transition(t *testing.T) {
 			tt.fields.conf.CommitTimeout = 5 * time.Millisecond
 			tt.fields.conf.SnapshotThreshold = 100
 			tt.fields.conf.TrailingLogs = 10
-			tt.fields.conf.skipStartup = true
+			tt.fields.conf.SkipStartup = true
 
 			// Create a raft instance and set the latest configuration
 			env1 := MakeRaft(t, tt.fields.conf, false)
@@ -2850,7 +2850,7 @@ func TestRaft_runFollower_ReloadTimeoutConfigs(t *testing.T) {
 	conf.CommitTimeout = 5 * time.Millisecond
 	conf.SnapshotThreshold = 100
 	conf.TrailingLogs = 10
-	conf.skipStartup = true
+	conf.SkipStartup = true
 
 	env := MakeRaft(t, conf, false)
 	servers := []Server{{Voter, "first", ""}}


### PR DESCRIPTION
This allow to instantiate a Raft object without starting the routines immediatly. It can be helpful for some use-cases (eg: creating observers before starting the raft goroutines ensure you won't miss any)