### PR TITLE
progress, state: use atomic method instead of mutex

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -100,7 +100,7 @@ type countingReader struct {
 
 func (r *countingReader) Read(p []byte) (n int, err error) {
 	n, err = r.reader.Read(p)
-	atomic.StoreInt64(&r.bytes, atomic.AddInt64(&r.bytes, int64(n)))
+	atomic.AddInt64(&r.bytes, int64(n))
 	return n, err
 }
 

--- a/state.go
+++ b/state.go
@@ -91,34 +91,22 @@ func (r *raftState) setCurrentTerm(term uint64) {
 	atomic.StoreUint64(&r.currentTerm, term)
 }
 
-func (r *raftState) getLastLog() (index, term uint64) {
-	r.lastLock.Lock()
-	index = r.lastLogIndex
-	term = r.lastLogTerm
-	r.lastLock.Unlock()
-	return
+func (r *raftState) getLastLog() (uint64, uint64) {
+	return atomic.LoadUint64(&r.lastLogIndex), atomic.LoadUint64(&r.lastLogTerm)
 }
 
 func (r *raftState) setLastLog(index, term uint64) {
-	r.lastLock.Lock()
-	r.lastLogIndex = index
-	r.lastLogTerm = term
-	r.lastLock.Unlock()
+	atomic.StoreUint64(&r.lastLogIndex, index)
+	atomic.StoreUint64(&r.lastLogTerm, term)
 }
 
-func (r *raftState) getLastSnapshot() (index, term uint64) {
-	r.lastLock.Lock()
-	index = r.lastSnapshotIndex
-	term = r.lastSnapshotTerm
-	r.lastLock.Unlock()
-	return
+func (r *raftState) getLastSnapshot() (uint64, uint64) {
+	return atomic.LoadUint64(&r.lastSnapshotIndex), atomic.LoadUint64(&r.lastSnapshotTerm)
 }
 
 func (r *raftState) setLastSnapshot(index, term uint64) {
-	r.lastLock.Lock()
-	r.lastSnapshotIndex = index
-	r.lastSnapshotTerm = term
-	r.lastLock.Unlock()
+	atomic.StoreUint64(&r.lastSnapshotIndex, index)
+	atomic.StoreUint64(&r.lastSnapshotTerm, term)
 }
 
 func (r *raftState) getCommitIndex() uint64 {
@@ -154,9 +142,9 @@ func (r *raftState) waitShutdown() {
 // getLastIndex returns the last index in stable storage.
 // Either from the last log or from the last snapshot.
 func (r *raftState) getLastIndex() uint64 {
-	r.lastLock.Lock()
-	defer r.lastLock.Unlock()
-	return max(r.lastLogIndex, r.lastSnapshotIndex)
+	logIndex := atomic.LoadUint64(&r.lastLogIndex)
+	snapIndex := atomic.LoadUint64(&r.lastSnapshotIndex)
+	return max(logIndex, snapIndex)
 }
 
 // getLastEntry returns the last index and term in stable storage.


### PR DESCRIPTION
`atomic` performs better than mutex. So I think it's good to use `atomic`.

This is my sanity test codes not used goroutine for check the performance.
If there's many goroutines, the race condition may happens frequently, and the performance difference will be even greater. 
```go
package test

import (
	"sync"
	"sync/atomic"
	"testing"
)

type Test struct {
	data uint32
	mu   sync.Mutex
}

// Set
func BenchmarkMutexSet(b *testing.B) {
	t := Test{}
	for i := 0; i < b.N; i++ {
		t.mu.Lock()
		t.data = uint32(i)
		t.mu.Unlock()
	}
}

func BenchmarkAtomicSet(b *testing.B) {
	t := Test{}
	for i := 0; i < b.N; i++ {
		atomic.StoreUint32(&t.data, uint32(i))
	}
}

// Load
func BenchmarkMutexLoad(b *testing.B) {
	t := Test{
		data: 1,
	}
	for i := 0; i < b.N; i++ {
		t.mu.Lock()
		_ = t.data
		t.mu.Unlock()
	}
}

func BenchmarkAtomicLoad(b *testing.B) {
	t := Test{
		data: 1,
	}
	for i := 0; i < b.N; i++ {
		_ = atomic.LoadUint32(&t.data)
	}
}
```

```
# Set
BenchmarkMutexSet-10             1000000                26.86 ns/op
BenchmarkAtomicSet-10            1000000                 0.4546 ns/op
# Load
BenchmarkMutexLoad-10            1000000                18.83 ns/op
BenchmarkAtomicLoad-10           1000000                 0.6662 ns/op
```

