### PR TITLE
Non voter with higher term should not cause cluster instability

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1380,7 +1380,7 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 	// in favor of the cluster current term to keep the cluster stable, as an election don't need to be started
 	// by a node which don't have voting rights.
 	currentTerm := r.getCurrentTerm()
-	hasVote := hasVote(r.configurations.latest, r.localID)
+	hasVote := hasVote(r.getLatestConfiguration(), r.localID)
 	if a.Term < currentTerm && !hasVote {
 		r.setState(Follower)
 		r.setCurrentTerm(a.Term)

--- a/replication.go
+++ b/replication.go
@@ -233,7 +233,7 @@ START:
 	appendStats(string(peer.ID), start, float32(len(req.Entries)))
 
 	// Check for a newer term, stop running
-	if resp.Term > req.Term {
+	if resp.Term > req.Term && s.peer.Suffrage != Nonvoter {
 		r.handleStaleTerm(s)
 		return true
 	}


### PR DESCRIPTION
As described in #524, when a non Voter with a higher term is added to the cluster the log replication to that node will fail, because it have higher term which ultimately cause the leader to step down and start an election.

This should not happen as the non voter node cannot win the election but at the same time the cluster expect the node with higher term to win the election, which get the cluster in a forever election loop.

In this PR a check is introduced to make sure that when a node receive an append entry request with a lower term and that node is a non voter it would accept it and overrite its own term to that lower term. That ensure the stability of the cluster and also break the loop as this node term is reset back to the cluster term.