### PR TITLE
check if server is in configuration when receiving a voteRequest

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -177,6 +177,17 @@ func hasVote(configuration Configuration, id ServerID) bool {
 	return false
 }
 
+// inConfiguration returns true if the server identified by 'id' is in in the
+// provided Configuration.
+func inConfiguration(configuration Configuration, id ServerID) bool {
+	for _, server := range configuration.Servers {
+		if server.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
 // checkConfiguration tests a cluster membership configuration for common
 // errors.
 func checkConfiguration(configuration Configuration) error {

--- a/raft.go
+++ b/raft.go
@@ -1566,8 +1566,8 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 		candidateID := ServerID(req.ID)
 		// if the Servers list is empty that mean the cluster is very likely trying to bootstrap,
 		// Grant the vote
-		if len(r.configurations.latest.Servers) > 0 && !hasVote(r.configurations.latest, candidateID) {
-			r.logger.Warn("rejecting vote request since node is not a voter",
+		if len(r.configurations.latest.Servers) > 0 && !inConfiguration(r.configurations.latest, candidateID) {
+			r.logger.Warn("rejecting vote request since node is not in configuration",
 				"from", candidate)
 			return
 		}

--- a/raft.go
+++ b/raft.go
@@ -1597,6 +1597,8 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 	// if we get a request for vote from a nonVoter  and the request term is higher,
 	// step down and update term, but reject the vote request
 	// This could happen when a node, previously voter, is converted to non-voter
+	// The reason we need to step in is to permit to the cluster to make progress in such a scenario
+	// More details about that in https://github.com/hashicorp/raft/pull/526
 	if len(req.ID) > 0 {
 		candidateID := ServerID(req.ID)
 		if len(r.configurations.latest.Servers) > 0 && !hasVote(r.configurations.latest, candidateID) {

--- a/raft_test.go
+++ b/raft_test.go
@@ -2675,7 +2675,7 @@ func TestRaft_ClusterCanRegainStability_WhenNonVoterWithHigherTermJoin(t *testin
 	}
 
 	//set that follower term to higher term to simulate a partitioning
-	followerRemoved.setCurrentTerm(leader.getCurrentTerm() + 2)
+	followerRemoved.setCurrentTerm(leader.getCurrentTerm() + 20)
 	//Add the node back as NonVoter
 	future = leader.AddNonvoter(followerRemoved.localID, followerRemoved.localAddr, 0, 0)
 	if err := future.Error(); err != nil {

--- a/raft_test.go
+++ b/raft_test.go
@@ -2644,6 +2644,85 @@ func TestRaft_VoteNotGranted_WhenNodeNotInCluster(t *testing.T) {
 	}
 }
 
+func TestRaft_ClusterCanRegainStability_WhenNonVoterWithHigherTermJoin(t *testing.T) {
+	// Make a cluster
+	c := MakeCluster(3, t, nil)
+
+	defer c.Close()
+
+	// Get the leader
+	leader := c.Leader()
+
+	// Wait until we have 2 followers
+	limit := time.Now().Add(c.longstopTimeout)
+	var followers []*Raft
+	for time.Now().Before(limit) && len(followers) != 2 {
+		c.WaitEvent(nil, c.conf.CommitTimeout)
+		followers = c.GetInState(Follower)
+	}
+	if len(followers) != 2 {
+		t.Fatalf("expected two followers: %v", followers)
+	}
+
+	// Remove a follower
+	followerRemoved := followers[0]
+	c.Disconnect(followerRemoved.localAddr)
+	time.Sleep(c.propagateTimeout)
+
+	future := leader.RemoveServer(followerRemoved.localID, 0, 0)
+	if err := future.Error(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	//set that follower term to higher term to simulate a partitioning
+	followerRemoved.setCurrentTerm(leader.getCurrentTerm() + 2)
+	//Add the node back as NonVoter
+	future = leader.AddNonvoter(followerRemoved.localID, followerRemoved.localAddr, 0, 0)
+	if err := future.Error(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	c.FullyConnect()
+
+	// Wait a while
+	time.Sleep(c.propagateTimeout)
+	// Check leader stable, could be a new leader here
+	leader = c.Leader()
+	//Write some logs to ensure they replicate
+	for i := 0; i < 100; i++ {
+		future := leader.Apply([]byte(fmt.Sprintf("test%d", i)), 0)
+		if err := future.Error(); err != nil {
+			t.Fatalf("[ERR] apply err: %v", err)
+		}
+	}
+	c.WaitForReplication(100)
+
+	//Remove the server and add it back as Voter
+	future = leader.RemoveServer(followerRemoved.localID, 0, 0)
+	if err := future.Error(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	leader.AddVoter(followerRemoved.localID, followerRemoved.localAddr, 0, 0)
+
+	// Wait a while
+	time.Sleep(c.propagateTimeout * 10)
+
+	//Write some logs to ensure they replicate
+	for i := 100; i < 200; i++ {
+		future := leader.Apply([]byte(fmt.Sprintf("test%d", i)), 0)
+		if err := future.Error(); err != nil {
+			t.Fatalf("[ERR] apply err: %v", err)
+		}
+	}
+	c.WaitForReplication(200)
+
+	// Check leader stable
+	newLeader := c.Leader()
+	if newLeader.leaderID != leader.leaderID {
+		t.Fatalf("leader changed")
+	}
+}
+
 // TestRaft_FollowerRemovalNoElection ensures that a leader election is not
 // started when a standby is shut down and restarted.
 func TestRaft_FollowerRemovalNoElection(t *testing.T) {


### PR DESCRIPTION
This PR change the check introduced in #477. 

Based on the bug reported in #524, when a non voter join the cluster with a higher term (This can happen in the case of a returning node to the cluster after a restart, that was pruned by autopilot) it causes the cluster to become unstable.

The scenario where this happen is the following:

- Stable cluster with `node0`, `node1`,`node2`. All nodes are voters
- node0 is partitioned from the cluster
- node0 is removed from the cluster by auto-pilote [`CleanupDeadServers`](https://learn.hashicorp.com/tutorials/consul/autopilot-datacenter-operations#dead-server-cleanup)It can't see the change (its configuration still have node0, node1, node2) and it still think it's a `Voter`
- the remaning cluster config is (node1,node2) a new leader is elected on term c1
- node0 transition to candidate and run elections until reaching c2>c1, this happen because it still think it's part of the cluster and it's a voter.
- partion is gone, the node try to rejoin the cluster (For Consul, this would happen through joining the serf pool, which allow the current cluster leader to add it back to the cluster)
- node0 is added by default as nonVoter, until raft see it caught up enough to transition to voter
- cluster replicate to node0 to try to make it aware of the new configuration and catch it up by performing an appendEntries CMD
- node0 reject the appendEntries CMD and the cluster start a new election
- a new leader is elected (not node0)
- cluster replicate to node0 to try  to make it aware of the new configuration and catch it up by performing an appendEntries CMD
- node0 reject the appendEntries CMD and the cluster start a new election
- ...

At the same time, node0 is still running as candidate (it still think it's part of the cluster and it's a voter) but, because of the fix introduced in #477, the request will be rejected which have the effect of increasing node0 term and make this unstable state permanent as node0 term is inflating and the cluster term will never catch-up to it.

The fix introduced in this PR break this loop, by allowing node0 to request a vote as a non voter which have the effect of levelling the term and let the cluster move forward. This is not ideal as it destabilize the cluster while node0 is guaranteed to not win the election.

An ideal fix would be to add pre-vote, #474 in conjunction to this to avoid term inflation and keep the cluster stable.


