### PR TITLE
Raft pre-vote extension implementation

### DIFF
--- a/api.go
+++ b/api.go
@@ -210,6 +210,9 @@ type Raft struct {
 
 	// mainThreadSaturation measures the saturation of the main raft goroutine.
 	mainThreadSaturation *saturationMetric
+
+	// preVote control if the pre-vote feature is activated
+	preVote bool
 }
 
 // BootstrapCluster initializes a server's storage with the given cluster
@@ -557,6 +560,7 @@ func NewRaft(conf *Config, fsm FSM, logs LogStore, stable StableStore, snaps Sna
 		leaderNotifyCh:        make(chan struct{}, 1),
 		followerNotifyCh:      make(chan struct{}, 1),
 		mainThreadSaturation:  newSaturationMetric([]string{"raft", "thread", "main", "saturation"}, 1*time.Second),
+		preVote:               conf.PreVote,
 	}
 
 	r.conf.Store(*conf)

--- a/commands.go
+++ b/commands.go
@@ -89,6 +89,7 @@ type RequestVoteRequest struct {
 	// transfer. It is required for leadership transfer to work, because servers
 	// wouldn't vote otherwise if they are aware of an existing leader.
 	LeadershipTransfer bool
+	PreVote            bool
 }
 
 // GetRPCHeader - See WithRPCHeader.
@@ -110,6 +111,9 @@ type RequestVoteResponse struct {
 
 	// Is the vote granted.
 	Granted bool
+
+	// Is it a preVote response
+	PreVote bool
 }
 
 // GetRPCHeader - See WithRPCHeader.

--- a/config.go
+++ b/config.go
@@ -25,67 +25,74 @@ import (
 // The version details are complicated, but here's a summary of what's required
 // to get from a version 0 cluster to version 3:
 //
-// 1. In version N of your app that starts using the new Raft library with
-//    versioning, set ProtocolVersion to 1.
-// 2. Make version N+1 of your app require version N as a prerequisite (all
-//    servers must be upgraded). For version N+1 of your app set ProtocolVersion
-//    to 2.
-// 3. Similarly, make version N+2 of your app require version N+1 as a
-//    prerequisite. For version N+2 of your app, set ProtocolVersion to 3.
+//  1. In version N of your app that starts using the new Raft library with
+//     versioning, set ProtocolVersion to 1.
+//  2. Make version N+1 of your app require version N as a prerequisite (all
+//     servers must be upgraded). For version N+1 of your app set ProtocolVersion
+//     to 2.
+//  3. Similarly, make version N+2 of your app require version N+1 as a
+//     prerequisite. For version N+2 of your app, set ProtocolVersion to 3.
 //
 // During this upgrade, older cluster members will still have Server IDs equal
 // to their network addresses. To upgrade an older member and give it an ID, it
 // needs to leave the cluster and re-enter:
 //
-// 1. Remove the server from the cluster with RemoveServer, using its network
-//    address as its ServerID.
-// 2. Update the server's config to use a UUID or something else that is
-//	  not tied to the machine as the ServerID (restarting the server).
-// 3. Add the server back to the cluster with AddVoter, using its new ID.
+//  1. Remove the server from the cluster with RemoveServer, using its network
+//     address as its ServerID.
+//  2. Update the server's config to use a UUID or something else that is
+//     not tied to the machine as the ServerID (restarting the server).
+//  3. Add the server back to the cluster with AddVoter, using its new ID.
 //
 // You can do this during the rolling upgrade from N+1 to N+2 of your app, or
 // as a rolling change at any time after the upgrade.
 //
-// Version History
+// # Version History
 //
 // 0: Original Raft library before versioning was added. Servers running this
-//    version of the Raft library use AddPeerDeprecated/RemovePeerDeprecated
-//    for all configuration changes, and have no support for LogConfiguration.
+//
+//	version of the Raft library use AddPeerDeprecated/RemovePeerDeprecated
+//	for all configuration changes, and have no support for LogConfiguration.
+//
 // 1: First versioned protocol, used to interoperate with old servers, and begin
-//    the migration path to newer versions of the protocol. Under this version
-//    all configuration changes are propagated using the now-deprecated
-//    RemovePeerDeprecated Raft log entry. This means that server IDs are always
-//    set to be the same as the server addresses (since the old log entry type
-//    cannot transmit an ID), and only AddPeer/RemovePeer APIs are supported.
-//    Servers running this version of the protocol can understand the new
-//    LogConfiguration Raft log entry but will never generate one so they can
-//    remain compatible with version 0 Raft servers in the cluster.
+//
+//	the migration path to newer versions of the protocol. Under this version
+//	all configuration changes are propagated using the now-deprecated
+//	RemovePeerDeprecated Raft log entry. This means that server IDs are always
+//	set to be the same as the server addresses (since the old log entry type
+//	cannot transmit an ID), and only AddPeer/RemovePeer APIs are supported.
+//	Servers running this version of the protocol can understand the new
+//	LogConfiguration Raft log entry but will never generate one so they can
+//	remain compatible with version 0 Raft servers in the cluster.
+//
 // 2: Transitional protocol used when migrating an existing cluster to the new
-//    server ID system. Server IDs are still set to be the same as server
-//    addresses, but all configuration changes are propagated using the new
-//    LogConfiguration Raft log entry type, which can carry full ID information.
-//    This version supports the old AddPeer/RemovePeer APIs as well as the new
-//    ID-based AddVoter/RemoveServer APIs which should be used when adding
-//    version 3 servers to the cluster later. This version sheds all
-//    interoperability with version 0 servers, but can interoperate with newer
-//    Raft servers running with protocol version 1 since they can understand the
-//    new LogConfiguration Raft log entry, and this version can still understand
-//    their RemovePeerDeprecated Raft log entries. We need this protocol version
-//    as an intermediate step between 1 and 3 so that servers will propagate the
-//    ID information that will come from newly-added (or -rolled) servers using
-//    protocol version 3, but since they are still using their address-based IDs
-//    from the previous step they will still be able to track commitments and
-//    their own voting status properly. If we skipped this step, servers would
-//    be started with their new IDs, but they wouldn't see themselves in the old
-//    address-based configuration, so none of the servers would think they had a
-//    vote.
+//
+//	server ID system. Server IDs are still set to be the same as server
+//	addresses, but all configuration changes are propagated using the new
+//	LogConfiguration Raft log entry type, which can carry full ID information.
+//	This version supports the old AddPeer/RemovePeer APIs as well as the new
+//	ID-based AddVoter/RemoveServer APIs which should be used when adding
+//	version 3 servers to the cluster later. This version sheds all
+//	interoperability with version 0 servers, but can interoperate with newer
+//	Raft servers running with protocol version 1 since they can understand the
+//	new LogConfiguration Raft log entry, and this version can still understand
+//	their RemovePeerDeprecated Raft log entries. We need this protocol version
+//	as an intermediate step between 1 and 3 so that servers will propagate the
+//	ID information that will come from newly-added (or -rolled) servers using
+//	protocol version 3, but since they are still using their address-based IDs
+//	from the previous step they will still be able to track commitments and
+//	their own voting status properly. If we skipped this step, servers would
+//	be started with their new IDs, but they wouldn't see themselves in the old
+//	address-based configuration, so none of the servers would think they had a
+//	vote.
+//
 // 3: Protocol adding full support for server IDs and new ID-based server APIs
-//    (AddVoter, AddNonvoter, etc.), old AddPeer/RemovePeer APIs are no longer
-//    supported. Version 2 servers should be swapped out by removing them from
-//    the cluster one-by-one and re-adding them with updated configuration for
-//    this protocol version, along with their server ID. The remove/add cycle
-//    is required to populate their server ID. Note that removing must be done
-//    by ID, which will be the old server's address.
+//
+//	(AddVoter, AddNonvoter, etc.), old AddPeer/RemovePeer APIs are no longer
+//	supported. Version 2 servers should be swapped out by removing them from
+//	the cluster one-by-one and re-adding them with updated configuration for
+//	this protocol version, along with their server ID. The remove/add cycle
+//	is required to populate their server ID. Note that removing must be done
+//	by ID, which will be the old server's address.
 type ProtocolVersion int
 
 const (
@@ -99,19 +106,22 @@ const (
 // Currently, it is always assumed that the server generates the latest version,
 // though this may be changed in the future to include a configurable version.
 //
-// Version History
+// # Version History
 //
 // 0: Original Raft library before versioning was added. The peers portion of
-//    these snapshots is encoded in the legacy format which requires decodePeers
-//    to parse. This version of snapshots should only be produced by the
-//    unversioned Raft library.
+//
+//	these snapshots is encoded in the legacy format which requires decodePeers
+//	to parse. This version of snapshots should only be produced by the
+//	unversioned Raft library.
+//
 // 1: New format which adds support for a full configuration structure and its
-//    associated log index, with support for server IDs and non-voting server
-//    modes. To ease upgrades, this also includes the legacy peers structure but
-//    that will never be used by servers that understand version 1 snapshots.
-//    Since the original Raft library didn't enforce any versioning, we must
-//    include the legacy peers structure for this version, but we can deprecate
-//    it in the next snapshot version.
+//
+//	associated log index, with support for server IDs and non-voting server
+//	modes. To ease upgrades, this also includes the legacy peers structure but
+//	that will never be used by servers that understand version 1 snapshots.
+//	Since the original Raft library didn't enforce any versioning, we must
+//	include the legacy peers structure for this version, but we can deprecate
+//	it in the next snapshot version.
 type SnapshotVersion int
 
 const (
@@ -221,6 +231,9 @@ type Config struct {
 
 	// skipStartup allows NewRaft() to bypass all background work goroutines
 	skipStartup bool
+
+	// PreVote activate the pre-vote feature
+	PreVote bool
 }
 
 func (conf *Config) getOrCreateLogger() hclog.Logger {

--- a/raft.go
+++ b/raft.go
@@ -315,13 +315,20 @@ func (r *Raft) runCandidate() {
 		case rpc := <-r.rpcCh:
 			r.mainThreadSaturation.working()
 			r.processRPC(rpc)
-
 		case vote := <-prevoteCh:
+			// This a pre-vote case but could lead to winning an election, in the case that majority of other nodes
+			// don't support pre-vote or have pre-vote deactivated.
 			r.mainThreadSaturation.working()
 			r.logger.Debug("got a prevote!!", "from", vote.voterID, "term", vote.Term, "tally", grantedVotes)
 			// Check if the term is greater than ours, bail
 			if vote.Term > r.getCurrentTerm() && !vote.PreVote {
 				r.logger.Debug("newer term discovered, fallback to follower", "term", vote.Term)
+				r.setState(Follower)
+				r.setCurrentTerm(vote.Term)
+				return
+			}
+			if vote.Term > term && vote.PreVote {
+				r.logger.Debug("newer term discovered on pre-vote, fallback to follower", "term", vote.Term)
 				r.setState(Follower)
 				r.setCurrentTerm(vote.Term)
 				return
@@ -339,14 +346,17 @@ func (r *Raft) runCandidate() {
 			}
 
 			// Check if we've become the leader
+			// If we won the election because the majority of nodes don't support pre-vote (or pre-vote is deactivated)
+			// set our state to leader and our term to the pre-vote term.
 			if grantedVotes >= votesNeeded {
 				r.logger.Info("election won", "term", vote.Term, "tally", grantedVotes)
 				r.setState(Leader)
 				r.setLeader(r.localAddr, r.localID)
-				//r.setCurrentTerm(term)
+
+				r.setCurrentTerm(term)
 				return
 			}
-			// Check if we've become the leader
+			// Check if we've won the pre-vote and proceed to election if so
 			if preVoteGrantedVotes >= votesNeeded {
 				r.logger.Info("pre election won", "term", vote.Term, "tally", preVoteGrantedVotes)
 				preVoteGrantedVotes = 0
@@ -1900,7 +1910,6 @@ func (r *Raft) electSelf(preVote bool) <-chan *voteResult {
 				resp.Granted = false
 				resp.PreVote = req.PreVote
 			}
-			r.logger.Warn("dhayachi::", "prevote-req", req.PreVote, "resp-prevote", resp.PreVote)
 			respCh <- resp
 		})
 	}
@@ -1950,7 +1959,6 @@ func (r *Raft) persistVote(term uint64, candidate []byte) error {
 
 // setCurrentTerm is used to set the current term in a durable manner.
 func (r *Raft) setCurrentTerm(t uint64) {
-	r.logger.Warn("dhayachi setting term", "term", t)
 	// Persist to disk first
 	if err := r.stable.SetUint64(keyCurrentTerm, t); err != nil {
 		panic(fmt.Errorf("failed to save current term: %v", err))

--- a/raft_test.go
+++ b/raft_test.go
@@ -2830,7 +2830,6 @@ func TestRaft_VoteWithNoIDNoAddr(t *testing.T) {
 	var resp RequestVoteResponse
 	followerT := c.trans[c.IndexOf(followers[1])]
 	c.Partition([]ServerAddress{leader.localAddr})
-	time.Sleep(c.propagateTimeout)
 
 	// wait for the remaining follower to trigger an election
 	waitForState(follower, Candidate)

--- a/raft_test.go
+++ b/raft_test.go
@@ -1916,6 +1916,62 @@ func TestRaft_AppendEntry(t *testing.T) {
 	require.True(t, resp2.Success)
 }
 
+func TestRaft_PreVoteMixedCluster_MajorityNoPreVote(t *testing.T) {
+
+	tcs := []struct {
+		name         string
+		prevoteNum   int
+		noprevoteNum int
+	}{
+		{"majority no pre-vote", 2, 3},
+		{"majority pre-vote", 3, 2},
+		{"all pre-vote", 3, 0},
+		{"all no pre-vote", 0, 3},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Make majority cluster.
+			majority := tc.prevoteNum
+			minority := tc.noprevoteNum
+			if tc.prevoteNum < tc.noprevoteNum {
+				majority = tc.noprevoteNum
+				minority = tc.prevoteNum
+			}
+
+			conf := inmemConfig(t)
+			conf.PreVote = tc.prevoteNum > tc.noprevoteNum
+			c := MakeCluster(majority, t, conf)
+			defer c.Close()
+
+			// Set up another server speaking protocol version 2.
+			conf = inmemConfig(t)
+			conf.PreVote = tc.prevoteNum < tc.noprevoteNum
+			c1 := MakeClusterNoBootstrap(minority, t, conf)
+
+			// Merge clusters.
+			c.Merge(c1)
+			c.FullyConnect()
+
+			if len(c1.rafts) > 0 {
+				future := c.Leader().AddVoter(c1.rafts[0].localID, c1.rafts[0].localAddr, 0, 0)
+				if err := future.Error(); err != nil {
+					t.Fatalf("err: %v", err)
+				}
+			}
+			time.Sleep(c.propagateTimeout * 10)
+
+			leaderOld := c.Leader()
+			c.Followers()
+			c.Partition([]ServerAddress{leaderOld.localAddr})
+			time.Sleep(c.propagateTimeout * 3)
+			leader := c.Leader()
+			require.NotEqual(t, leader.leaderID, leaderOld.leaderID)
+		})
+	}
+
+}
+
 func TestRaft_VotingGrant_WhenLeaderAvailable(t *testing.T) {
 	conf := inmemConfig(t)
 	conf.ProtocolVersion = 3


### PR DESCRIPTION
This is an idea to implement pre-vote without breaking backward compatibility I'm exploring.

Pre-vote, based on the original raft thesis, is an extension to raft that help reduce term inflation and cluster instability when a node is partitioned from the cluster for a while and then is back online.

In normal election when a node have no leader, it transition into candidate state. In that state the node will try to run an election by incrementing its term and sending a vote-request to the other nodes in the cluster.

If the node win the election, the node become a leader and the cluster is stable again. But in the event that this node don't win the election, let's say because it's not connected to a quorum of nodes in the cluster, it will retry by incrementing it's term again and running another round of election. That could happen multiple times, which create a term inflation.

Once the node is connected back to quorum of nodes it's almost certain that its term will be higher than the other nodes in the cluster, as it was running rounds of elections non stop, while most likely the remaining of the cluster was stable. This will lead to the node making the current raft leader to step-down and another round of election is run. That's not a desired behaviour because the cluster was already stable and that node most likely don't have the latest log, so it won't be able to win the election anyway.


In this PR, a new `bool` called `preVote` is introduced to both the `RequestVoteRequest` and `RequestVoteResponse`. When a node transition to a candidate state and pre-vote is activated in the config, it will run a round of pre-election by sending RequestVoteRequest with `preVote` set to `true` and a term equal its current term + 1 but without incrementing its current term.

If the node that receive the request support pre-vote and have pre-vote activated, it will respond by sending a `RequestVoteResponse` with `preVote` set to true and grant its vote as if it's a normal election, but without incrementing its vote.

Otherwise the node will respond by sending a `RequestVoteResponse` with `preVote` set to false and grant its vote as it does for normal election, including incrementing its term.

The candidate node will count all the votes with `preVote` set to true, `grantedPrevotes` and all the votes with `preVote` set to false, `grantedVotes`.

If `grantedPrevotes` is bigger than the needed votes the candidate will run a normal election.

If `grantedVotes` is bigger than the needed votes the candidate will consider it self winning the election and transition to leader.

