### PR TITLE
Post restore reset

### DIFF
--- a/api.go
+++ b/api.go
@@ -645,6 +645,14 @@ func (r *Raft) restoreSnapshot() error {
 		r.setCommittedConfiguration(conf, index)
 		r.setLatestConfiguration(conf, index)
 
+		// Remove old logs if r.logs is a MonotonicLogStore. Log any errors and
+		// continue.
+		if logs, ok := r.logs.(MonotonicLogStore); ok && logs.IsMonotonic() {
+			if err := r.removeOldLogs(); err != nil {
+				r.logger.Error("failed to reset logs", "error", err)
+			}
+		}
+
 		// Success!
 		return nil
 	}

--- a/api.go
+++ b/api.go
@@ -645,14 +645,6 @@ func (r *Raft) restoreSnapshot() error {
 		r.setCommittedConfiguration(conf, index)
 		r.setLatestConfiguration(conf, index)
 
-		// Remove old logs if r.logs is a MonotonicLogStore. Log any errors and
-		// continue.
-		if logs, ok := r.logs.(MonotonicLogStore); ok && logs.IsMonotonic() {
-			if err := r.removeOldLogs(); err != nil {
-				r.logger.Error("failed to reset logs", "error", err)
-			}
-		}
-
 		// Success!
 		return nil
 	}

--- a/log.go
+++ b/log.go
@@ -130,13 +130,13 @@ type LogStore interface {
 }
 
 // MonotonicLogStore is an optional interface for LogStore implementations that
-// cannot tolerate gaps in between the Index values of consecutive log entries. For example, 
-// this may allow more efficient indexing because the Index values are densely populated. If true is 
-// returned, Raft will avoid relying on gaps to trigger re-synching logs on followers after a 
-// snapshot is restored. The LogStore must have an efficient implementation of 
-// DeleteLogs, as this called after every snapshot restore when gaps are not allowed. 
-// We avoid deleting all records for LogStores that do not implement MonotonicLogStore 
-// because this has a major negative performance impact on the BoltDB store that is currently 
+// cannot tolerate gaps in between the Index values of consecutive log entries. For example,
+// this may allow more efficient indexing because the Index values are densely populated. If true is
+// returned, Raft will avoid relying on gaps to trigger re-synching logs on followers after a
+// snapshot is restored. The LogStore must have an efficient implementation of
+// DeleteLogs, as this called after every snapshot restore when gaps are not allowed.
+// We avoid deleting all records for LogStores that do not implement MonotonicLogStore
+// because this has a major negative performance impact on the BoltDB store that is currently
 // the most widely used.
 type MonotonicLogStore interface {
 	IsMonotonic() bool

--- a/log.go
+++ b/log.go
@@ -134,9 +134,9 @@ type LogStore interface {
 // this may allow more efficient indexing because the Index values are densely populated. If true is
 // returned, Raft will avoid relying on gaps to trigger re-synching logs on followers after a
 // snapshot is restored. The LogStore must have an efficient implementation of
-// DeleteLogs, as this called after every snapshot restore when gaps are not allowed.
+// DeleteLogs for the case where all logs are removed, as this must be called after snapshot restore when gaps are not allowed.
 // We avoid deleting all records for LogStores that do not implement MonotonicLogStore
-// because this has a major negative performance impact on the BoltDB store that is currently
+// because although it's always correct to do so, it has a major negative performance impact on the BoltDB store that is currently
 // the most widely used.
 type MonotonicLogStore interface {
 	IsMonotonic() bool

--- a/log_cache.go
+++ b/log_cache.go
@@ -33,6 +33,16 @@ func NewLogCache(capacity int, store LogStore) (*LogCache, error) {
 	return c, nil
 }
 
+// IsMonotonic implements the MonotonicLogStore interface. This is a shim to
+// expose the underyling store as monotonically indexed or not.
+func (c *LogCache) IsMonotonic() bool {
+	if store, ok := c.store.(MonotonicLogStore); ok {
+		return store.IsMonotonic()
+	}
+
+	return false
+}
+
 func (c *LogCache) GetLog(idx uint64, log *Log) error {
 	// Check the buffer for an entry
 	c.l.RLock()

--- a/raft.go
+++ b/raft.go
@@ -1129,7 +1129,7 @@ func (r *Raft) restoreUserSnapshot(meta *SnapshotMeta, reader io.Reader) error {
 		}
 	}
 
-	r.logger.Info("restored user snapshot", "index", latestIndex)
+	r.logger.Info("restored user snapshot", "index", lastIndex)
 	return nil
 }
 

--- a/raft_test.go
+++ b/raft_test.go
@@ -1020,7 +1020,7 @@ func TestRaft_SnapshotRestore(t *testing.T) {
 	}
 }
 
-func TestRaft_SnapshotRestore_Monotonic(t *testing.T) {
+func TestRaft_RestoreSnapshotOnStartup_Monotonic(t *testing.T) {
 	// Make the cluster
 	conf := inmemConfig(t)
 	conf.TrailingLogs = 10

--- a/raft_test.go
+++ b/raft_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1019,6 +1020,79 @@ func TestRaft_SnapshotRestore(t *testing.T) {
 	}
 }
 
+func TestRaft_SnapshotRestore_Monotonic(t *testing.T) {
+	// Make the cluster
+	conf := inmemConfig(t)
+	conf.TrailingLogs = 10
+	opts := &MakeClusterOpts{
+		Peers:         1,
+		Bootstrap:     true,
+		Conf:          conf,
+		MonotonicLogs: true,
+	}
+	c := MakeClusterCustom(t, opts)
+	defer c.Close()
+
+	leader := c.Leader()
+
+	// Commit a lot of things
+	var future Future
+	for i := 0; i < 100; i++ {
+		future = leader.Apply([]byte(fmt.Sprintf("test%d", i)), 0)
+	}
+
+	// Wait for the last future to apply
+	if err := future.Error(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Take a snapshot
+	snapFuture := leader.Snapshot()
+	if err := snapFuture.Error(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check for snapshot
+	snaps, _ := leader.snapshots.List()
+	if len(snaps) != 1 {
+		t.Fatalf("should have a snapshot")
+	}
+	snap := snaps[0]
+
+	// Logs should be trimmed
+	if idx, _ := leader.logs.FirstIndex(); idx != snap.Index-conf.TrailingLogs+1 {
+		t.Fatalf("should trim logs to %d: but is %d", snap.Index-conf.TrailingLogs+1, idx)
+	}
+
+	// Shutdown
+	shutdown := leader.Shutdown()
+	if err := shutdown.Error(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Restart the Raft
+	r := leader
+	// Can't just reuse the old transport as it will be closed
+	_, trans2 := NewInmemTransport(r.trans.LocalAddr())
+	cfg := r.config()
+	r, err := NewRaft(&cfg, r.fsm, r.logs, r.stable, r.snapshots, trans2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	c.rafts[0] = r
+
+	// We should have restored from the snapshot!
+	if last := r.getLastApplied(); last != snap.Index {
+		t.Fatalf("bad last index: %d, expecting %d", last, snap.Index)
+	}
+
+	// Verify that logs have been reset
+	first, _ := r.logs.FirstIndex()
+	last, _ := r.logs.LastIndex()
+	assert.Zero(t, first)
+	assert.Zero(t, last)
+}
+
 func TestRaft_SnapshotRestore_Progress(t *testing.T) {
 	// Make the cluster
 	conf := inmemConfig(t)
@@ -1342,7 +1416,7 @@ func TestRaft_UserSnapshot(t *testing.T) {
 
 // snapshotAndRestore does a snapshot and restore sequence and applies the given
 // offset to the snapshot index, so we can try out different situations.
-func snapshotAndRestore(t *testing.T, offset uint64) {
+func snapshotAndRestore(t *testing.T, offset uint64, monotonicLogStore bool) {
 	// Make the cluster.
 	conf := inmemConfig(t)
 
@@ -1352,7 +1426,18 @@ func snapshotAndRestore(t *testing.T, offset uint64) {
 	conf.ElectionTimeout = 500 * time.Millisecond
 	conf.LeaderLeaseTimeout = 500 * time.Millisecond
 
-	c := MakeCluster(3, t, conf)
+	var c *cluster
+	if monotonicLogStore {
+		opts := &MakeClusterOpts{
+			Peers:         3,
+			Bootstrap:     true,
+			Conf:          conf,
+			MonotonicLogs: true,
+		}
+		c = MakeClusterCustom(t, opts)
+	} else {
+		c = MakeCluster(3, t, conf)
+	}
 	defer c.Close()
 
 	// Wait for things to get stable and commit some things.
@@ -1448,7 +1533,10 @@ func TestRaft_UserRestore(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("case %v", c), func(t *testing.T) {
-			snapshotAndRestore(t, c)
+			snapshotAndRestore(t, c, false)
+		})
+		t.Run(fmt.Sprintf("monotonic case %v", c), func(t *testing.T) {
+			snapshotAndRestore(t, c, true)
 		})
 	}
 }
@@ -2380,6 +2468,7 @@ func TestRaft_LeadershipTransferStopRightAway(t *testing.T) {
 		t.Errorf("leadership shouldn't have started, but instead it error with: %v", err)
 	}
 }
+
 func TestRaft_GetConfigurationNoBootstrap(t *testing.T) {
 	c := MakeCluster(2, t, nil)
 	defer c.Close()

--- a/snapshot.go
+++ b/snapshot.go
@@ -210,10 +210,10 @@ func (r *Raft) takeSnapshot() (string, error) {
 	return sink.ID(), nil
 }
 
-// compactLogs takes the last inclusive index of a snapshot
-// and trims the logs that are no longer needed.
-func (r *Raft) compactLogs(snapIdx uint64) error {
-	defer metrics.MeasureSince([]string{"raft", "compactLogs"}, time.Now())
+// compactLogsWithTrailing takes the last inclusive index of a snapshot,
+// the lastLogIdx, and and the trailingLogs and trims the logs that
+// are no longer needed.
+func (r *Raft) compactLogsWithTrailing(snapIdx uint64, lastLogIdx uint64, trailingLogs uint64) error {
 	// Determine log ranges to compact
 	minLog, err := r.logs.FirstIndex()
 	if err != nil {
@@ -221,11 +221,8 @@ func (r *Raft) compactLogs(snapIdx uint64) error {
 	}
 
 	// Check if we have enough logs to truncate
-	lastLogIdx, _ := r.getLastLog()
-
 	// Use a consistent value for trailingLogs for the duration of this method
 	// call to avoid surprising behaviour.
-	trailingLogs := r.config().TrailingLogs
 	if lastLogIdx <= trailingLogs {
 		return nil
 	}
@@ -250,28 +247,32 @@ func (r *Raft) compactLogs(snapIdx uint64) error {
 	return nil
 }
 
+// compactLogs takes the last inclusive index of a snapshot
+// and trims the logs that are no longer needed.
+func (r *Raft) compactLogs(snapIdx uint64) error {
+	defer metrics.MeasureSince([]string{"raft", "compactLogs"}, time.Now())
+
+	lastLogIdx, _ := r.getLastLog()
+	trailingLogs := r.config().TrailingLogs
+
+	return r.compactLogsWithTrailing(snapIdx, lastLogIdx, trailingLogs)
+}
+
 // removeOldLogs removes all old logs from the store. This is used for
 // MonotonicLogStores after restore. Callers should verify that the store
 // implementation is monotonic prior to calling.
 func (r *Raft) removeOldLogs() error {
 	defer metrics.MeasureSince([]string{"raft", "removeOldLogs"}, time.Now())
 
-	// Determine log ranges to truncate
-	firstLogIdx, err := r.logs.FirstIndex()
-	if err != nil {
-		return fmt.Errorf("failed to get first log index: %w", err)
-	}
-
 	lastLogIdx, err := r.logs.LastIndex()
 	if err != nil {
 		return fmt.Errorf("failed to get last log index: %w", err)
 	}
 
-	r.logger.Info("removing all old logs from log store", "first", firstLogIdx, "last", lastLogIdx)
+	r.logger.Info("removing all old logs from log store")
 
-	if err := r.logs.DeleteRange(firstLogIdx, lastLogIdx); err != nil {
-		return fmt.Errorf("log truncation failed: %v", err)
-	}
-
-	return nil
+	// call compactLogsWithTrailing with lastLogIdx for snapIdx since
+	// it will take the lesser of lastLogIdx and snapIdx to figure out
+	// the end for which to apply trailingLogs.
+	return r.compactLogsWithTrailing(lastLogIdx, lastLogIdx, 0)
 }

--- a/testing.go
+++ b/testing.go
@@ -133,6 +133,47 @@ func (m *MockSnapshot) Persist(sink SnapshotSink) error {
 func (m *MockSnapshot) Release() {
 }
 
+// MockMonotonicLogStore is a stubbed LogStore wrapper for testing the
+// MonotonicLogStore interface.
+type MockMonotonicLogStore struct {
+	s LogStore
+}
+
+// IsMonotonic implements the MonotonicLogStore interface.
+func (m *MockMonotonicLogStore) IsMonotonic() bool {
+	return true
+}
+
+// FirstIndex implements the LogStore interface.
+func (m *MockMonotonicLogStore) FirstIndex() (uint64, error) {
+	return m.s.FirstIndex()
+}
+
+// LastIndex implements the LogStore interface.
+func (m *MockMonotonicLogStore) LastIndex() (uint64, error) {
+	return m.s.LastIndex()
+}
+
+// GetLog implements the LogStore interface.
+func (m *MockMonotonicLogStore) GetLog(index uint64, log *Log) error {
+	return m.s.GetLog(index, log)
+}
+
+// StoreLog implements the LogStore interface.
+func (m *MockMonotonicLogStore) StoreLog(log *Log) error {
+	return m.s.StoreLog(log)
+}
+
+// StoreLogs implements the LogStore interface.
+func (m *MockMonotonicLogStore) StoreLogs(logs []*Log) error {
+	return m.s.StoreLogs(logs)
+}
+
+// DeleteRange implements the LogStore interface.
+func (m *MockMonotonicLogStore) DeleteRange(min uint64, max uint64) error {
+	return m.s.DeleteRange(min, max)
+}
+
 // This can be used as the destination for a logger and it'll
 // map them into calls to testing.T.Log, so that you only see
 // the logging for failed tests.


### PR DESCRIPTION
This PR introduces an interface which acts as a handler for a leaky
abstraction in the structure of underlying log stores. In order to
properly handle post-snapshot-restore cleanup for log stores
generically, we need some awareness of whether the underlying store
permits gaps.

Boltdb allows for gaps in log store indexes, but to handle them it
requires a freelist, which is written on every commit. This is costly,
particularly when the freelist is large. By completely resetting the
LogStore after snapshot restore, we grow the size of the freelist, which would result in performance degradation.

The MonotonicLogStore interface is implemented by LogStores with
guarantees of sequential/monotonic indexes, like raft-wal, but reverts
to the old behavior for for LogStores with index holes, like Boltdb.

The interface also requires special handling within LogStore wrappers (like LogCache), to ensure that the type assertion is passed to the underlying store.

We then use the MonotonicLogStore type assertion to delete all
entries from the LogStore after snapshot restore.