### PR TITLE
add CommitIndex API

### DIFF
--- a/api.go
+++ b/api.go
@@ -1194,6 +1194,13 @@ func (r *Raft) LastIndex() uint64 {
 	return r.getLastIndex()
 }
 
+// CommitIndex returns the committed index.
+// This API maybe helpful for server to implement the read index optimization 
+// as described in the Raft paper.
+func (r *Raft) CommitIndex() uint64 {
+	return r.getCommitIndex()
+}
+
 // AppliedIndex returns the last index applied to the FSM. This is generally
 // lagging behind the last index, especially for indexes that are persisted but
 // have not yet been considered committed by the leader. NOTE - this reflects

--- a/api.go
+++ b/api.go
@@ -1195,7 +1195,7 @@ func (r *Raft) LastIndex() uint64 {
 }
 
 // CommitIndex returns the committed index.
-// This API maybe helpful for server to implement the read index optimization 
+// This API maybe helpful for server to implement the read index optimization
 // as described in the Raft paper.
 func (r *Raft) CommitIndex() uint64 {
 	return r.getCommitIndex()


### PR DESCRIPTION
This API is useful for implementing the read index optimization as described in the Raft paper.