### PR TITLE
Document some Apply error cases better

### DIFF
--- a/api.go
+++ b/api.go
@@ -797,7 +797,7 @@ func (r *Raft) LeaderWithID() (ServerAddress, ServerID) {
 //
 // If a user snapshot is restored while the command is in-flight, an 
 // ErrAbortedByRestore is returned. In this case the write effectively failed
-// since it's effects will not be present in the FSM after the restore.
+// since its effects will not be present in the FSM after the restore.
 func (r *Raft) Apply(cmd []byte, timeout time.Duration) ApplyFuture {
 	return r.ApplyLog(Log{Data: cmd}, timeout)
 }

--- a/api.go
+++ b/api.go
@@ -788,14 +788,14 @@ func (r *Raft) LeaderWithID() (ServerAddress, ServerID) {
 // An optional timeout can be provided to limit the amount of time we wait
 // for the command to be started. This must be run on the leader or it
 // will fail.
-// 
+//
 // If the node discovers it is no longer the leader while applying the command,
-// it will return ErrLeadershipLost. There is no way to guarantee whether the 
-// write succeeded or failed in this case. For example, if the leader is 
+// it will return ErrLeadershipLost. There is no way to guarantee whether the
+// write succeeded or failed in this case. For example, if the leader is
 // partitioned it can't know if a quorum of followers wrote the log to disk. If
 // at least one did, it may survive into the next leader's term.
 //
-// If a user snapshot is restored while the command is in-flight, an 
+// If a user snapshot is restored while the command is in-flight, an
 // ErrAbortedByRestore is returned. In this case the write effectively failed
 // since its effects will not be present in the FSM after the restore.
 func (r *Raft) Apply(cmd []byte, timeout time.Duration) ApplyFuture {

--- a/api.go
+++ b/api.go
@@ -788,12 +788,23 @@ func (r *Raft) LeaderWithID() (ServerAddress, ServerID) {
 // An optional timeout can be provided to limit the amount of time we wait
 // for the command to be started. This must be run on the leader or it
 // will fail.
+// 
+// If the node discovers it is no longer the leader while applying the command,
+// it will return ErrLeadershipLost. There is no way to guarantee whether the 
+// write succeeded or failed in this case. For example, if the leader is 
+// partitioned it can't know if a quorum of followers wrote the log to disk. If
+// at least one did, it may survive into the next leader's term.
+//
+// If a user snapshot is restored while the command is in-flight, an 
+// ErrAbortedByRestore is returned. In this case the write effectively failed
+// since it's effects will not be present in the FSM after the restore.
 func (r *Raft) Apply(cmd []byte, timeout time.Duration) ApplyFuture {
 	return r.ApplyLog(Log{Data: cmd}, timeout)
 }
 
 // ApplyLog performs Apply but takes in a Log directly. The only values
-// currently taken from the submitted Log are Data and Extensions.
+// currently taken from the submitted Log are Data and Extensions. See
+// Apply for details on error cases.
 func (r *Raft) ApplyLog(log Log, timeout time.Duration) ApplyFuture {
 	metrics.IncrCounter([]string{"raft", "apply"}, 1)
 


### PR DESCRIPTION
It isn't clear what `ErrLeadershipLost` means in terms of write success or failure. This aims to clarify that it's indeterminate and there is nothing stronger we can say about that in general.

It _could_ be possible to avoid this case in some types of leadership loss or shutdown, but we can't make a stronger guarantee in all cases so there will always be at least some cases where the result is "we don't know if this committed or not".

For example, if the leader in a three node cluster has been partitioned from both followers, it will eventually lose leadership. When it does, any in-flight commands are in an indeterminate state. If they have been received and written to disk by at least one follower, then it is likely that that follower will become the new leader and "commit" them in it's new term. If none of the followers has received the request before the partition then the write will be lost completely. Since the partitioned leader can't communicate with the followers, it can't find out which outcome is right and so must return `ErrLeadershipLost` which implies "I don't have enough information to say whether this committed or not but I can't make progress as I'm not the leader any more".