### PR TITLE
Optimize appendEntries to panic error in brain-split situation

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1388,9 +1388,13 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 		return
 	}
 
+	if a.Term == r.getCurrentTerm() && r.getState() == Leader {
+		panic("brain split")
+	}
+
 	// Increase the term if we see a newer one, also transition to follower
 	// if we ever get an appendEntries call
-	if a.Term > r.getCurrentTerm() || (r.getState() != Follower && !r.candidateFromLeadershipTransfer) {
+	if a.Term > r.getCurrentTerm() || (r.getState() == Candidate && !r.candidateFromLeadershipTransfer) {
 		// Ensure transition to follower
 		r.setState(Follower)
 		r.setCurrentTerm(a.Term)


### PR DESCRIPTION
This commit panic brain-split error in appendEntries call when state is leader and term equals requester term.
https://github.com/hashicorp/raft/issues/568