### PR TITLE
Fix race with `candidateFromLeadershipTransfer`

### DIFF
--- a/api.go
+++ b/api.go
@@ -134,7 +134,7 @@ type Raft struct {
 	// candidate because the leader tries to transfer leadership. This flag is
 	// used in RequestVoteRequest to express that a leadership transfer is going
 	// on.
-	candidateFromLeadershipTransfer bool
+	candidateFromLeadershipTransfer atomic.Bool
 
 	// Stores our local server ID, used to avoid sending RPCs to ourself
 	localID ServerID


### PR DESCRIPTION
Fix #517 

`candidateFromLeadershipTransfer` is used to notify that a leadership transfer is ongoing and transition nodes to candidate state directly without going through follower state. As a leader is already in place transitioning to follower state will avoid leadership transfer happening.

This PR fix a race condition as this bool ,`candidateFromLeadershipTransfer`, is read in the [appendEntries processing](https://github.com/hashicorp/raft/blob/da0ac467de7a8d2450180ba20dea08017c8d266e/raft.go#L1393-L1393) while written in the state processing routine (in both runCandidate and possibly runFollower).

See https://github.com/hashicorp/raft/issues/517 for a stack trace of the Data Race