### PR TITLE
Reproduce leadership transfer failures when writes happen during transfer

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -211,12 +211,16 @@ func newTestLogger(tb testing.TB) hclog.Logger {
 // is logged after the test is complete.
 func newTestLoggerWithPrefix(tb testing.TB, prefix string) hclog.Logger {
 	if testing.Verbose() {
-		return hclog.New(&hclog.LoggerOptions{Name: prefix})
+		return hclog.New(&hclog.LoggerOptions{
+			Name:  prefix,
+			Level: hclog.Trace,
+		})
 	}
 
 	return hclog.New(&hclog.LoggerOptions{
 		Name:   prefix,
 		Output: &testLoggerAdapter{tb: tb, prefix: prefix},
+		Level:  hclog.Trace,
 	})
 }
 


### PR DESCRIPTION
Also fix the problem partially: it can still occur if we dispatchLogs after the transfer message has been sent to the target, before it wins the election.