### PR TITLE
fix: serialize NetworkTransport data race on ServerAddr()

### DIFF
--- a/net_transport.go
+++ b/net_transport.go
@@ -91,6 +91,7 @@ type NetworkTransport struct {
 	maxPool     int
 	maxInFlight int
 
+	serverAddressLock     sync.RWMutex
 	serverAddressProvider ServerAddressProvider
 
 	shutdown     bool
@@ -384,6 +385,8 @@ func (n *NetworkTransport) getConnFromAddressProvider(id ServerID, target Server
 }
 
 func (n *NetworkTransport) getProviderAddressOrFallback(id ServerID, target ServerAddress) ServerAddress {
+	n.serverAddressLock.RLock()
+	defer n.serverAddressLock.RUnlock()
 	if n.serverAddressProvider != nil {
 		serverAddressOverride, err := n.serverAddressProvider.ServerAddr(id)
 		if err != nil {


### PR DESCRIPTION
`ServerAddr()` is called concurrently through `AppendEntries`, `RequestVote`. 
for example `getConn()` is thread safe [here](https://github.com/hashicorp/raft/blob/cc2bb080d64f172ff2fcad13289e7ec07dd2e6c6/net_transport.go#L383) by calling `connPoolLock`, however `getProviderAddressOrFallback()` is not thread safe.
 
given that the lib doesn't control which data type is used by the consumer and there is no documentation for how `ServerAddr()` could be used by RAFT lib, so this PR protecting reading `ServerAddr()` by adding `RWMutex` to the `NetworkTransport` and serialize access to `serverAddressLock` 