### PR TITLE
github: add nomad-eng to codeowners file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @hashicorp/consul-core-reviewers
+* @hashicorp/consul-core-reviewers @hashicorp/nomad-eng
 
 /.release/                           @hashicorp/release-engineering
 /.github/workflows/ci.yml            @hashicorp/release-engineering


### PR DESCRIPTION
Allows the Nomad engineering team to be notified of PR's and better help with reviews and library work.