### PR TITLE
Fix flaky raft tests, checking for candidate state

### DIFF
--- a/raft_test.go
+++ b/raft_test.go
@@ -2959,7 +2959,6 @@ func TestRaft_VoteNotGranted_WhenNodeNotInCluster(t *testing.T) {
 
 	// wait for the remaining follower to trigger an election
 	waitForState(follower, Candidate)
-	require.Equal(t, Candidate, follower.getState())
 
 	// send a vote request from the removed follower to the Candidate follower
 	if err := followerRemovedT.RequestVote(follower.localID, follower.localAddr, &reqVote, &resp); err != nil {
@@ -3161,9 +3160,8 @@ func TestRaft_VoteWithNoIDNoAddr(t *testing.T) {
 
 	// wait for the remaining follower to trigger an election
 	waitForState(follower, Candidate)
-	require.Equal(t, Candidate, follower.getState())
-	// send a vote request from the removed follower to the Candidate follower
 
+	// send a vote request from the removed follower to the Candidate follower
 	if err := followerT.RequestVote(follower.localID, follower.localAddr, &reqVote, &resp); err != nil {
 		t.Fatalf("RequestVote RPC failed %v", err)
 	}


### PR DESCRIPTION
In some tests in `raft_test.go` we have the following pattern:

```golang
// wait for the remaining follower to trigger an election
waitForState(follower, Candidate)
require.Equal(t, Candidate, follower.getState())
```
The issue with this pattern is that candidate state is a transient state and a node is not expected to stay in it for a long time, so by the time we finish `waitForState(follower, Candidate)` and get the state again the new node state could already have changed.