### PR TITLE
Do not update leader last-contact when granting a pre-vote request

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1805,7 +1805,6 @@ func (r *Raft) requestPreVote(rpc RPC, req *RequestPreVoteRequest) {
 	}
 
 	resp.Granted = true
-	r.setLastContact()
 }
 
 // installSnapshot is invoked when we get a InstallSnapshot RPC call.


### PR DESCRIPTION
# Description
This fix a theoretical bug with pre-vote. The issue could happen when a former leader continuously send pre-vote requests to former followers before they get the chance to transition to Candidates without necessarily winning the pre-vote election (because they haven't got enough pre-vote granted for example). This could happen in a scenario when a node is misconfigured and have a low election timeout with a node configured differently from the others.

In that scenario, the pre-vote request will set the leader last contact in the node in follower state which prevent it from going to Candidate state and could render the cluster unstable for undetermined time.


# Testing
I added an integration test that recreate the condition artificially. The test execute the following steps:

- Create a 3 nodes cluster with a deterministic leader
- Start a routine that continuously send pre-vote requests to all the followers
- Deactivate heartbeat from the leader to the followers
- Check that a new leader is elected out of the followers

I executed the test with and without the fix and it consistently pass/fail based on it.