### PR TITLE
Support retrieving current term

### DIFF
--- a/api.go
+++ b/api.go
@@ -1208,8 +1208,8 @@ func (r *Raft) Stats() map[string]string {
 	return s
 }
 
-// Term returns the current term.
-func (r *Raft) Term() uint64 {
+// CurrentTerm returns the current term.
+func (r *Raft) CurrentTerm() uint64 {
 	return r.getCurrentTerm()
 }
 

--- a/api.go
+++ b/api.go
@@ -1208,6 +1208,11 @@ func (r *Raft) Stats() map[string]string {
 	return s
 }
 
+// Term returns the current term.
+func (r *Raft) Term() uint64 {
+	return r.getCurrentTerm()
+}
+
 // LastIndex returns the last index in stable storage,
 // either from the last log or from the last snapshot.
 func (r *Raft) LastIndex() uint64 {


### PR DESCRIPTION
Simple addition to make this internal variable accessible (without relying on `stats` object, which is a brittle approach).

_Term_ is a fundamental concept in Raft consensus, so making it easily available to clients of this library seems like an obvious thing to do. There are also specific use cases supported by knowing the Term:

- Allow clients of this library to retrieve and display diagnostic information about the state of the Raft system.
- Support certain types of reads of a Raft-managed store. For example, if a client can check before and after a Read that an election has not taken place during the read, it allows those clients to make certain guarantees about the data read from the Raft-managed Store. One way to do this is to simply check that the Term has not changed (see [this discussion](https://groups.google.com/g/raft-dev/c/4QlyV0aptEQ/m/1JxcmSgRAwAJ) for more details).