### PR TITLE
Support checking assertion of Leadership

### DIFF
--- a/future.go
+++ b/future.go
@@ -44,6 +44,18 @@ type ApplyFuture interface {
 	Response() interface{}
 }
 
+// AssertedFuture is used to check if the current node has asserted leadership.
+// A Leader asserts leadership by committing at least one log in this term.
+type AssertedFuture interface {
+	Future
+
+	// Asserted returns true if the current node has asserted leadership.
+	Asserted() bool
+
+	// Term returns the term in which the leadership was asserted.
+	Term() uint64
+}
+
 // ConfigurationFuture is used for GetConfiguration and can return the
 // latest configuration in use by Raft.
 type ConfigurationFuture interface {
@@ -241,6 +253,20 @@ type verifyFuture struct {
 	quorumSize int
 	votes      int
 	voteLock   sync.Mutex
+}
+
+type assertedFuture struct {
+	deferError
+	asserted bool
+	term     uint64
+}
+
+func (a *assertedFuture) Asserted() bool {
+	return a.asserted
+}
+
+func (a *assertedFuture) Term() uint64 {
+	return a.term
 }
 
 // leadershipTransferFuture is used to track the progress of a leadership

--- a/raft.go
+++ b/raft.go
@@ -185,6 +185,11 @@ func (r *Raft) runFollower() {
 			// Reject any operations since we are not the leader
 			v.respond(ErrNotLeader)
 
+		case v := <-r.assertedCh:
+			r.mainThreadSaturation.working()
+			// Reject any operations since we are not the leader
+			v.respond(ErrNotLeader)
+
 		case ur := <-r.userRestoreCh:
 			r.mainThreadSaturation.working()
 			// Reject any restores since we are not the leader
@@ -394,6 +399,11 @@ func (r *Raft) runCandidate() {
 			a.respond(ErrNotLeader)
 
 		case v := <-r.verifyCh:
+			r.mainThreadSaturation.working()
+			// Reject any operations since we are not the leader
+			v.respond(ErrNotLeader)
+
+		case v := <-r.assertedCh:
 			r.mainThreadSaturation.working()
 			// Reject any operations since we are not the leader
 			v.respond(ErrNotLeader)
@@ -676,6 +686,10 @@ func (r *Raft) leaderLoop() {
 	// based on the current config value.
 	lease := time.After(r.config().LeaderLeaseTimeout)
 
+	// Track whether leadership has been asserted. This is true as long
+	// as the leader has committed at least one log in this term.
+	leadershipAsserted := false
+
 	for r.getState() == Leader {
 		r.mainThreadSaturation.sleeping()
 
@@ -788,6 +802,7 @@ func (r *Raft) leaderLoop() {
 			oldCommitIndex := r.getCommitIndex()
 			commitIndex := r.leaderState.commitment.getCommitIndex()
 			r.setCommitIndex(commitIndex)
+			leadershipAsserted = true
 
 			// New configuration has been committed, set it as the committed
 			// value.
@@ -868,6 +883,12 @@ func (r *Raft) leaderLoop() {
 				}
 				v.respond(nil)
 			}
+
+		case v := <-r.assertedCh:
+			r.mainThreadSaturation.working()
+			v.asserted = leadershipAsserted
+			v.term = r.getCurrentTerm()
+			v.respond(nil)
 
 		case future := <-r.userRestoreCh:
 			r.mainThreadSaturation.working()


### PR DESCRIPTION
This allows clients of this library to check if the current node, assuming it is the Leader, has explicitly asserted leadership in the current term. "Asserting" is defined has having committed at least one log entry in the current term, as per the Raft paper.

This change adds a new channel, which is only serviced when in Leadership mode. This channel will respond with the asserted status via a Future. Clients are recommended to call this function only until they have confirmed that the leadership has been asserted. Once asserted for a given term the state can be cached until the end of the term.

This code is necessary to properly implement the Read Optimization outlined in the Raft paper and dissertation. The dissertation explains that it is not sufficient to simply check the Leader's commit index. Instead a client must first confirm that the Leader has explicitly asserted leadership by committing a log entry in the current term. Only then is commit index valid.