### PR TITLE
Add linter rules to ensure we don't accidentally emit metrics directly instead of through the compat package

### DIFF
--- a/.golangci-lint.yml
+++ b/.golangci-lint.yml
@@ -9,6 +9,17 @@ linters-settings:
     check-shadowing: true
   golint:
     min-confidence: 0
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        allow:
+          - "github.com/hashicorp/go-metrics/compat"
+        deny:
+          - pkg: "github.com/hashicorp/go-metrics"
+            desc: not allowed, use github.com/hashicorp/go-metrics/compat instead
+          - pkg: "github.com/armon/go-metrics"
+            desc: not allowed, use github.com/hashicorp/go-metrics/compat instead
 
 linters:
   disable-all: true
@@ -16,6 +27,7 @@ linters:
     - gofmt
     #- golint
     - govet
+    - depguard
     #- varcheck
     #- typecheck
     #- gosimple


### PR DESCRIPTION
My previous PR switched the repo over to emitting metrics via github.com/hashicorp/go-metrics/compat. In discussions with other engineers it came up that if new metrics are added it would be good to ensure that they use the compat package as well. To that end, this PR introduces linter rules to ensure only the compat package is used.