### PR TITLE
Add a log line on active node when sending snapshot to a follower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ _testmain.go
 
 *.exe
 *.test
+
+# Goland IDE
+.idea

--- a/replication.go
+++ b/replication.go
@@ -337,12 +337,12 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 	peer := s.peer
 	s.peerLock.RUnlock()
 
-	r.logger.Info("installing snapshot on", "peer", peer, "id", snapID, "size", req.Size)
+	r.logger.Info("installing snapshot on", "peer", peer.ID, "id", snapID, "size", req.Size)
 	// Make the call
 	start := time.Now()
 	var resp InstallSnapshotResponse
 	if err := r.trans.InstallSnapshot(peer.ID, peer.Address, &req, &resp, snapshot); err != nil {
-		r.logger.Error("failed to install snapshot", "id", snapID, "error", err)
+		r.logger.Error("failed to install snapshot", "peer", peer.ID, "id", snapID, "error", err)
 		s.failures++
 		return false, err
 	}
@@ -376,7 +376,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 		s.notifyAll(true)
 	} else {
 		s.failures++
-		r.logger.Warn("installSnapshot rejected to", "peer", peer)
+		r.logger.Warn("installSnapshot rejected to", "peer", peer.ID, "id", snapID)
 	}
 	return false, nil
 }

--- a/replication.go
+++ b/replication.go
@@ -337,6 +337,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 	peer := s.peer
 	s.peerLock.RUnlock()
 
+	r.logger.Info("installing snapshot on", "peer", peer, "id", snapID, "size", req.Size)
 	// Make the call
 	start := time.Now()
 	var resp InstallSnapshotResponse

--- a/replication.go
+++ b/replication.go
@@ -311,6 +311,7 @@ func (r *Raft) sendLatestSnapshot(s *followerReplication) (bool, error) {
 
 	// Open the most recent snapshot
 	snapID := snapshots[0].ID
+	r.logger.Info("opening snapshot", "id", snapID)
 	meta, snapshot, err := r.snapshots.Open(snapID)
 	if err != nil {
 		r.logger.Error("failed to open snapshot", "id", snapID, "error", err)


### PR DESCRIPTION
This change is motivated by a request from Vault's support to make it easier to understand the progress of replication. 

Currently, we do some logging on the standby nodes, but our support would like to be able to see what is happening in the logs earlier, especially in Vault deployments when the active node is slow/overwhelmed or when it has a big database.