### PR TITLE
reduce error report for non-error

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -79,16 +79,16 @@ func (r *Raft) runSnapshots() {
 			}
 
 			// Trigger a snapshot
-			if _, err := r.takeSnapshot(); err != nil {
+			if _, err := r.takeSnapshot(); err != nil && err != ErrNothingNewToSnapshot {
 				r.logger.Error("failed to take snapshot", "error", err)
 			}
 
 		case future := <-r.userSnapshotCh:
 			// User-triggered, run immediately
 			id, err := r.takeSnapshot()
-			if err != nil {
+			if err != nil && err != ErrNothingNewToSnapshot {
 				r.logger.Error("failed to take snapshot", "error", err)
-			} else {
+			} else if err == nil {
 				future.opener = func() (*SnapshotMeta, io.ReadCloser, error) {
 					return r.snapshots.Open(id)
 				}

--- a/snapshot.go
+++ b/snapshot.go
@@ -4,11 +4,12 @@
 package raft
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"time"
 
-	"github.com/hashicorp/go-metrics/compat"
+	metrics "github.com/hashicorp/go-metrics/compat"
 )
 
 // SnapshotMeta is for metadata of a snapshot.
@@ -79,14 +80,14 @@ func (r *Raft) runSnapshots() {
 			}
 
 			// Trigger a snapshot
-			if _, err := r.takeSnapshot(); err != nil && err != ErrNothingNewToSnapshot {
+			if _, err := r.takeSnapshot(); err != nil && !errors.Is(err, ErrNothingNewToSnapshot) {
 				r.logger.Error("failed to take snapshot", "error", err)
 			}
 
 		case future := <-r.userSnapshotCh:
 			// User-triggered, run immediately
 			id, err := r.takeSnapshot()
-			if err != nil && err != ErrNothingNewToSnapshot {
+			if err != nil && !errors.Is(err, ErrNothingNewToSnapshot) {
 				r.logger.Error("failed to take snapshot", "error", err)
 			} else if err == nil {
 				future.opener = func() (*SnapshotMeta, io.ReadCloser, error) {


### PR DESCRIPTION
We were worried about "failed to take snapshot" only to discover the real underlying error was "nothing new to snapshot". Guess it is better to not report that as an error.

Fixes: https://github.com/hashicorp/raft/issues/637