### PR TITLE
Add WaitCommitted

### DIFF
--- a/future_test.go
+++ b/future_test.go
@@ -43,3 +43,35 @@ func TestDeferFutureConcurrent(t *testing.T) {
 		t.Errorf("unexpected error result; got %#v want %#v", got, want)
 	}
 }
+
+func TestLogFutureWaitCommittedError(t *testing.T) {
+	assert := func(t *testing.T, want error, fn func() error) {
+		t.Helper()
+		if got := fn(); got != want {
+			t.Fatalf("unexpected error result; got %#v want %#v", got, want)
+		}
+	}
+
+	t.Run("ErrorBeforeCommitted", func(t *testing.T) {
+		want := errors.New("x")
+		var f logFuture
+		f.init()
+		f.respond(want)
+		assert(t, want, f.WaitCommitted)
+		assert(t, want, f.WaitCommitted)
+		assert(t, want, f.Error)
+		assert(t, want, f.Error)
+	})
+
+	t.Run("ErrorAfterCommitted", func(t *testing.T) {
+		want := errors.New("x")
+		var f logFuture
+		f.init()
+		close(f.committed)
+		f.respond(want)
+		assert(t, nil, f.WaitCommitted)
+		assert(t, want, f.Error)
+		assert(t, nil, f.WaitCommitted)
+		assert(t, want, f.Error)
+	})
+}

--- a/raft.go
+++ b/raft.go
@@ -569,6 +569,7 @@ func (r *Raft) runLeader() {
 	// maintain that there exists at most one uncommitted configuration entry in
 	// any log, so we have to do proper no-ops here.
 	noop := &logFuture{log: Log{Type: LogNoop}}
+	noop.init()
 	r.dispatchLogs([]*logFuture{noop})
 
 	// Sit in the leader loop until we step down
@@ -818,6 +819,7 @@ func (r *Raft) leaderLoop() {
 				groupReady = append(groupReady, e)
 				groupFutures[idx] = commitLog
 				lastIdxInGroup = idx
+				close(commitLog.committed)
 			}
 
 			// Process the group


### PR DESCRIPTION
Hello team,
 
Just wanted to say thanks for the awesome work on this project – it's been a pleasure to work with. We're using raft in a new experimental component we're building over at [Grafana Pyroscope](https://github.com/grafana/pyroscope), and it's been super helpful.

As part of our integration, we encountered a use case where quorum replication is sufficient for correctness, and blocking until FSM application introduces unnecessary latency. This PR proposes a small addition that enables that workflow in a clean and backward-compatible way: the new `WaitCommitted()` method in the `ApplyFuture` interface. Unlike `ApplyFuture.Error()`, which blocks until the command has been committed and applied to the local FSM, `WaitCommitted()` allows users to wait only until the log entry has been replicated to a quorum and marked committed – without blocking on FSM application.

I'm happy to implement the feature in a different way if needed – the code in the PR is just one option I considered. Testing for the new API is also not particularly extensive at the moment, but I'd be more than willing to fill in the gaps if the general idea is accepted.

 