### PR TITLE
Enhance network transport debugging

### DIFF
--- a/net_transport.go
+++ b/net_transport.go
@@ -626,6 +626,11 @@ func (n *NetworkTransport) handleConn(connCtx context.Context, conn net.Conn) {
 			if err != io.EOF {
 				n.logger.Error("failed to decode incoming command", "error", err)
 			}
+			if r.Buffered() > 0 {
+				snippet := [100]byte{}
+				cnt, _ := r.Read(snippet[:])
+				n.logger.Error("remaining read buffer", "sz", cnt, "data", string(snippet[:cnt]))
+			}
 			return
 		}
 		if err := w.Flush(); err != nil {


### PR DESCRIPTION
Adds a couple of things for debuggability and stability:

1. When a follower fails to process an incoming RPC request for any reason, print up to 100 bytes of the remaining buffered bytes in the incoming connection.  This gives more detail for being able to resolve weird network issues where the client has msgpack decoding issues or is getting outright gibberish in the RPC request without needing client at remote sites to have to resort to packet captures or hand-decoding TLS encrypted streams.
2. Have the leader reset buffers and codecs for pooled network connections whenever they are pulled from the pool, and arrange for things to panic if anything tries to use a pooled conn when it has not been checked out.