### PR TITLE
IND-3918 Dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,37 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 version: 2
 
 updates:
-  - package-ecosystem: "gomod"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "sunday"
+    commit-message:
+      prefix: "[chore] : "
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/fuzzy"
+      - "/raft-compat"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    commit-message:
+      prefix: "[chore] : "
+    groups:
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,7 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 version: 2
 
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
-    commit-message:
-      prefix: "[chore] : "
-    groups:
-      actions:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "gomod"
-    directories:
-      - "/"
-      - "/fuzzy"
-      - "/raft-compat"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    commit-message:
-      prefix: "[chore] : "
-    groups:
-      go:
-        patterns:
-          - "*"
-        applies-to: "version-updates"
-      go-security:
-        patterns:
-          - "*"
-        applies-to: "security-updates"


### PR DESCRIPTION
As per the memo: https://go.hashi.co/memo/eng-004,
Enabling the dependabot for identifying and updating the security and version updates in the repositories rather handling it manually.