### PR TITLE
Snapshot rpc error fixes

### DIFF
--- a/fuzzy/go.mod
+++ b/fuzzy/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/hashicorp/go-hclog v1.6.2
-	github.com/hashicorp/go-msgpack/v2 v2.1.1
+	github.com/hashicorp/go-msgpack/v2 v2.1.2
 	github.com/hashicorp/raft v1.2.0
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 )

--- a/fuzzy/go.sum
+++ b/fuzzy/go.sum
@@ -40,6 +40,7 @@ github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack/v2 v2.1.1 h1:xQEY9yB2wnHitoSzk/B9UjXWRQ67QKu5AOm8aFp8N3I=
 github.com/hashicorp/go-msgpack/v2 v2.1.1/go.mod h1:upybraOAblm4S7rx0+jeNy+CWWhzywQsSRV5033mMu4=
+github.com/hashicorp/go-msgpack/v2 v2.1.2/go.mod h1:upybraOAblm4S7rx0+jeNy+CWWhzywQsSRV5033mMu4=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=


### PR DESCRIPTION
Followers can get confused if the leader streams a Snapshot that is larger than indicated by the snapshot metadata.  Fix this in a few different ways:

1. When the leader issues an install snapshot RPC, only copy the number of bytes the metadata says to.  This ensures there is no extra data on the wire even if the snapshot size grows in between the time the RPC was started and the time the snapshot is streamed over the network.
2. On the follower side, discard any remaining buffered bytes left over on the conn after processing the install RPC.
3. Also on the follower side, exit the event processing loop after handling a  install snapshot RPC.  The leader has never attempted to reuse a conn after sending a snapshot, so the follower should do the same thing.

This PR also includes the changes I made while tracking this issue down, including logging the first 100 bytes left over after handling an unknown RPC and being more aggressive about buffer management with pooled conns (including poisoning any conns returned to the pool).