### PR TITLE
[IND-4227][COMPLIANCE] chore: update build tags to modern format

### DIFF
--- a/fuzzy/fsm_batch.go
+++ b/fuzzy/fsm_batch.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build batchtest
-// +build batchtest
 
 package fuzzy
 

--- a/testing_batch.go
+++ b/testing_batch.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build batchtest
-// +build batchtest
 
 package raft
 


### PR DESCRIPTION


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description
- Replaced all deprecated `// +build` directives with the modern `//go:build` form introduced in Go 1.17. This modernizes build constraints to align with the latest Go toolchain and removes obsolete syntax flagged by go vet linter.

- No runtime or functional behavior changes.

⚠️ Note: This change drops compatibility with Go versions earlier than 1.17, as they do not support the `//go:build` syntax.
<!-- Provide a summary of what the PR does and why it is being submitted. -->

## Related Issue
This change is required to fix lint issues that appeared during CI checks in #658 .
<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

## How Has This Been Tested?
`golangci-lint cache clean && golangci-lint run ./...`
<!-- Describe how the changes have been tested. Provide test instructions or details. -->
