### PR TITLE
fix: make fuzz run without fuzzy harness errors

### DIFF
--- a/fuzzy/cluster.go
+++ b/fuzzy/cluster.go
@@ -5,6 +5,7 @@ package fuzzy
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,6 +21,14 @@ import (
 type appliedItem struct {
 	index uint64
 	data  []byte
+}
+
+type staticErrorFuture struct {
+	err error
+}
+
+func (s staticErrorFuture) Error() error {
+	return s.err
 }
 
 type cluster struct {
@@ -230,6 +239,9 @@ func (c *cluster) generateNApplies(s *applySource, n uint) [][]byte {
 
 func (c *cluster) leadershipTransfer(leaderTimeout time.Duration) raft.Future {
 	ldr := c.Leader(leaderTimeout)
+	if ldr == nil {
+		return staticErrorFuture{err: errors.New("no leader elected before leadership transfer")}
+	}
 	return ldr.raft.LeadershipTransfer()
 }
 

--- a/fuzzy/leadershiptransfer_test.go
+++ b/fuzzy/leadershiptransfer_test.go
@@ -19,15 +19,21 @@ func TestRaft_FuzzyLeadershipTransfer(t *testing.T) {
 	s := newApplySource("LeadershipTransfer")
 	data := cluster.generateNApplies(s, uint(r.Intn(10000)))
 	futures := cluster.sendNApplies(time.Minute, data)
-	cluster.leadershipTransfer(time.Minute)
+	if err := cluster.leadershipTransfer(time.Minute).Error(); err != nil {
+		t.Fatalf("leadership transfer failed: %v", err)
+	}
 
 	data = cluster.generateNApplies(s, uint(r.Intn(10000)))
 	futures = append(futures, cluster.sendNApplies(time.Minute, data)...)
-	cluster.leadershipTransfer(time.Minute)
+	if err := cluster.leadershipTransfer(time.Minute).Error(); err != nil {
+		t.Fatalf("leadership transfer failed: %v", err)
+	}
 
 	data = cluster.generateNApplies(s, uint(r.Intn(10000)))
 	futures = append(futures, cluster.sendNApplies(time.Minute, data)...)
-	cluster.leadershipTransfer(time.Minute)
+	if err := cluster.leadershipTransfer(time.Minute).Error(); err != nil {
+		t.Fatalf("leadership transfer failed: %v", err)
+	}
 
 	data = cluster.generateNApplies(s, uint(r.Intn(10000)))
 	futures = append(futures, cluster.sendNApplies(time.Minute, data)...)
@@ -37,6 +43,20 @@ func TestRaft_FuzzyLeadershipTransfer(t *testing.T) {
 	cluster.Stop(t, time.Minute)
 	cluster.VerifyLog(t, ac)
 	cluster.VerifyFSM(t)
+}
+
+func TestRaft_FuzzyLeadershipTransferWithoutLeader(t *testing.T) {
+	cluster := newRaftCluster(t, testLogWriter, "lt_no_leader", 5, nil)
+
+	if err := cluster.leadershipTransfer(0).Error(); err == nil {
+		t.Fatal("expected leadership transfer to fail when no leader can be elected")
+	}
+
+	for _, n := range cluster.nodes {
+		if err := n.raft.Shutdown().Error(); err != nil {
+			t.Fatalf("shutdown failed for %s: %v", n.name, err)
+		}
+	}
 }
 
 type LeadershipTransferMode int

--- a/fuzzy/transport.go
+++ b/fuzzy/transport.go
@@ -113,6 +113,7 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 	}
 	rpc := raft.RPC{RespChan: rc}
 	var reqVote raft.RequestVoteRequest
+	var reqPreVote raft.RequestPreVoteRequest
 	var timeoutNow raft.TimeoutNowRequest
 	var appEnt raft.AppendEntriesRequest
 	dec := codec.NewDecoderBytes(buff.Bytes(), &codecHandle)
@@ -127,6 +128,11 @@ func (t *transport) sendRPC(target string, req interface{}, resp interface{}) er
 			return err
 		}
 		rpc.Command = &reqVote
+	case *raft.RequestPreVoteRequest:
+		if err := dec.Decode(&reqPreVote); err != nil {
+			return err
+		}
+		rpc.Command = &reqPreVote
 	case *raft.AppendEntriesRequest:
 		if err := dec.Decode(&appEnt); err != nil {
 			return err


### PR DESCRIPTION
Hi friends long time no see. I was trying to run `make fuzz` locally and it panicked relatively quickly which was surprising. I then saw it wasn't because it found a bug bug, just a bug in the harness :/ The fix did not seem that complicated though. I wonder if we should run these regularly (or least annually?) or remove them

clanker generated pr desc below

---
## Summary

This PR fixes fuzzy-harness failures that could make `make fuzz` fail for harness reasons unrelated to Raft correctness.

Specifically, it:
- adds missing pre-vote RPC decoding in the fuzzy transport
- makes fuzzy leadership transfer fail via `Future.Error()` when no leader exists, instead of panicking
- adds/strengthens leadership-transfer fuzzy tests to assert the no-leader path is handled explicitly

## Problem

`make fuzz` was not reliably usable as a correctness signal because the harness had two gaps:

1. **Missing pre-vote decode path in `fuzzy/transport.go`**
   - The transport handled `RequestVote`, `AppendEntries`, etc., but did not decode `RequestPreVoteRequest` inside `sendRPC`.
   - This is a historical integration gap: pre-vote support was introduced later (PR `#530`, commit `181475c`), while the fuzzy transport code path predates that work. The `RequestPreVote` method was added, but the decode switch was not updated for the new request type.
   - In pre-vote election paths this produced errors such as:
     - `unexpected request type: *raft.RequestPreVoteRequest`
     - `RPC does not have a header`
   - Result: election traffic could fail in the harness even when Raft behavior itself was not the issue.

2. **Nil dereference during leadership transfer in `fuzzy/cluster.go`**
   - `cluster.leadershipTransfer()` assumed a leader existed and dereferenced `ldr.raft`.
   - Under realistic fuzz timing (no stable leader yet), this panicked instead of returning a normal failure signal.
   - Result: test process crashes (false-negative fuzz failure mode) instead of actionable test output.

## Impact of the bug

The impact is on **test reliability and signal quality**:
- `make fuzz` could fail due to harness defects, not Raft logic.
- Panics terminate runs early, reducing explored interleavings.
- Engineers can waste time triaging harness noise rather than real protocol problems.
- CI/local fuzz runs lose trustworthiness as an early regression detector.

## Why this fix is necessary

Fuzzing is only useful when the harness both:
- models expected protocol traffic correctly, and
- reports failures deterministically.

Without this fix, pre-vote election traffic is mis-modeled and no-leader transfer scenarios crash instead of returning explicit errors.

## Why this is more correct

This change aligns the harness with Raft expectations and Go API contracts:
- **Transport correctness:** pre-vote requests are decoded and routed like other supported RPC types.
- **Failure-semantics correctness:** no-leader transfer returns an error future instead of panicking.
- **Regression protection:** tests now assert explicit no-leader behavior.

In short, failures become deterministic and diagnosable test failures rather than runtime panics.

## Scope / Risk

Scope is intentionally narrow:
- `fuzzy/cluster.go`
- `fuzzy/leadershiptransfer_test.go`
- `fuzzy/transport.go`

No Raft core algorithm changes, no CI workflow changes.

## Test Plan

- [x] `go test -count=1 -run 'TestRaft_FuzzyLeadershipTransfer|TestRaft_FuzzyLeadershipTransferWithoutLeader' ./fuzzy`
- [x] `make fuzz`