### PR TITLE
Remove ip-compliance team from CODEOWNERS, transfer ownership to raft-force/consul-core-reviewers/nomad-eng

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owner
-* @hashicorp/team-ip-compliance @hashicorp/consul-core-reviewers @hashicorp/nomad-eng @hashicorp/raft-force
+* @hashicorp/raft-force @hashicorp/consul-core-reviewers @hashicorp/nomad-eng
 
 # Add override rules below. Each line is a file/folder pattern followed by one or more owners.
 # Being an owner means those groups or individuals will be added as reviewers to PRs affecting


### PR DESCRIPTION
## Summary
- Remove `@hashicorp/team-ip-compliance` as code owner
- Transfer ownership to `@hashicorp/raft-force`, `@hashicorp/consul-core-reviewers`, and `@hashicorp/nomad-eng`

Requested by IP compliance team to transfer repository ownership to the appropriate teams.