### PR TITLE
address linter fixes

### DIFF
--- a/inmem_store.go
+++ b/inmem_store.go
@@ -135,10 +135,6 @@ func (i *InmemStore) GetUint64(key []byte) (uint64, error) {
 	return i.kvInt[string(key)], nil
 }
 
-type commitIndexTrackingLog struct {
-	log         *Log
-	CommitIndex uint64
-}
 type InmemCommitTrackingStore struct {
 	InmemStore
 	commitIndex atomic.Uint64

--- a/raft_test.go
+++ b/raft_test.go
@@ -1262,6 +1262,9 @@ func TestRaft_RestoreCommittedLogs(t *testing.T) {
 		t.Fatal("err: raft log store does not implement CommitTrackingLogStore interface")
 	}
 	commitIdx, err := store.GetCommitIndex()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
 	// We should have applied all committed logs
 	if last := r.getLastApplied(); last != commitIdx {
 		t.Fatalf("bad last index: %d, expecting %d", last, commitIdx)


### PR DESCRIPTION
When we merged #613 it was not current on main so it didn't have the linter configuration we'd have needed to catch these minor issues. This PR should make CI green.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
