### PR TITLE
Heartbeat term bump races with the leader loop, diverges logs

### DIFF
--- a/api.go
+++ b/api.go
@@ -140,6 +140,21 @@ type Raft struct {
 	// on.
 	candidateFromLeadershipTransfer atomic.Bool
 
+	// rpcTransitionLock serializes the "observe a higher term -> step down to
+	// follower" transition that can be triggered concurrently from two places:
+	// the main raft thread (via processRPC) and the transport I/O thread (via
+	// the async heartbeat fast-path, processHeartbeat). HashiCorp Raft handles
+	// heartbeat AppendEntries on the transport thread to keep the election
+	// timeout decoupled from disk latency, but a heartbeat carrying a newer
+	// term mutates currentTerm and state just like any other AppendEntries.
+	// Without serialization that mutation can interleave with the main thread
+	// in the middle of dispatching a log entry or handling another RPC, which
+	// is exactly the race that produces the data-divergence safety violation
+	// described in https://github.com/hashicorp/raft/issues/695. The lock makes
+	// the check-and-set of (state, currentTerm) atomic with respect to both
+	// callers so a node can never act on a term it has already superseded.
+	rpcTransitionLock sync.Mutex
+
 	// Stores our local server ID, used to avoid sending RPCs to ourself
 	localID ServerID
 

--- a/api.go
+++ b/api.go
@@ -140,19 +140,8 @@ type Raft struct {
 	// on.
 	candidateFromLeadershipTransfer atomic.Bool
 
-	// rpcTransitionLock serializes the "observe a higher term -> step down to
-	// follower" transition that can be triggered concurrently from two places:
-	// the main raft thread (via processRPC) and the transport I/O thread (via
-	// the async heartbeat fast-path, processHeartbeat). HashiCorp Raft handles
-	// heartbeat AppendEntries on the transport thread to keep the election
-	// timeout decoupled from disk latency, but a heartbeat carrying a newer
-	// term mutates currentTerm and state just like any other AppendEntries.
-	// Without serialization that mutation can interleave with the main thread
-	// in the middle of dispatching a log entry or handling another RPC, which
-	// is exactly the race that produces the data-divergence safety violation
-	// described in https://github.com/hashicorp/raft/issues/695. The lock makes
-	// the check-and-set of (state, currentTerm) atomic with respect to both
-	// callers so a node can never act on a term it has already superseded.
+	// rpcTransitionLock serializes term/state transitions between the main
+	// raft thread and the async heartbeat I/O thread.
 	rpcTransitionLock sync.Mutex
 
 	// Stores our local server ID, used to avoid sending RPCs to ourself

--- a/api.go
+++ b/api.go
@@ -140,8 +140,14 @@ type Raft struct {
 	// on.
 	candidateFromLeadershipTransfer atomic.Bool
 
-	// rpcTransitionLock serializes term/state transitions between the main
-	// raft thread and the async heartbeat I/O thread.
+	// rpcTransitionLock serializes transitions of the (state, currentTerm)
+	// pair between the main raft thread and the transport I/O thread, which
+	// can step the node down concurrently via a fast-path heartbeat. Writers
+	// that move state and/or currentTerm as part of one transition must hold
+	// the lock for the whole transition, and appendEntries additionally holds
+	// it across the term check that decides to transition, so concurrent
+	// step-downs cannot interleave. The atomic accessors (getState,
+	// getCurrentTerm) may be read without the lock.
 	rpcTransitionLock sync.Mutex
 
 	// Stores our local server ID, used to avoid sending RPCs to ourself

--- a/integ_test.go
+++ b/integ_test.go
@@ -481,7 +481,14 @@ func TestRaft_RestartFollower_LongInitialHeartbeat(t *testing.T) {
 				env1.Shutdown()
 				time.Sleep(50 * time.Millisecond)
 				require.Equal(t, uint32(0), atomic.LoadUint32(requestVotes))
-				time.Sleep(600 * time.Millisecond)
+
+				// Poll for request votes instead of a fixed sleep. The
+				// heartbeat timeout plus election timeout can exceed 600ms
+				// on loaded CI runners, so a fixed sleep is flaky.
+				deadline := time.Now().Add(2 * time.Second)
+				for time.Now().Before(deadline) && atomic.LoadUint32(requestVotes) == 0 {
+					time.Sleep(50 * time.Millisecond)
+				}
 				require.NotEqual(t, uint32(0), atomic.LoadUint32(requestVotes))
 			}
 

--- a/raft.go
+++ b/raft.go
@@ -1247,17 +1247,6 @@ func (r *Raft) dispatchLogs(applyLogs []*logFuture) {
 	term := r.getCurrentTerm()
 	lastIndex := r.getLastIndex()
 
-	// A heartbeat on the I/O thread can flip us to Follower mid-dispatch.
-	// Refuse to append under a term we no longer lead.
-	if r.getCurrentTerm() != term {
-		r.logger.Warn("aborting log dispatch, leadership lost before append",
-			"term", term, "currentTerm", r.getCurrentTerm())
-		for _, applyLog := range applyLogs {
-			applyLog.respond(ErrLeadershipLost)
-		}
-		return
-	}
-
 	n := len(applyLogs)
 	logs := make([]*Log, n)
 	metrics.SetGauge([]string{"raft", "leader", "dispatchNumLogs"}, float32(n))
@@ -1489,8 +1478,7 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 	r.rpcTransitionLock.Lock()
 	if a.Term > r.getCurrentTerm() || (r.getState() != Follower && !r.candidateFromLeadershipTransfer.Load()) {
 		// Ensure transition to follower
-		r.setState(Follower)
-		r.setCurrentTerm(a.Term)
+		r.transitionToFollowerLocked(a.Term)
 		resp.Term = a.Term
 	}
 	r.rpcTransitionLock.Unlock()
@@ -2179,14 +2167,20 @@ func (r *Raft) setCurrentTerm(t uint64) {
 	r.raftState.setCurrentTerm(t)
 }
 
+// transitionToFollowerLocked steps down to follower and adopts the given
+// term. Callers must hold rpcTransitionLock; see appendEntries.
+func (r *Raft) transitionToFollowerLocked(term uint64) {
+	r.setState(Follower)
+	r.setCurrentTerm(term)
+}
+
 // transitionToFollower steps down to follower and adopts the given term. It
 // is serialized against the transport I/O thread, which may step the node
 // down concurrently via a fast-path heartbeat.
 func (r *Raft) transitionToFollower(term uint64) {
 	r.rpcTransitionLock.Lock()
 	defer r.rpcTransitionLock.Unlock()
-	r.setState(Follower)
-	r.setCurrentTerm(term)
+	r.transitionToFollowerLocked(term)
 }
 
 // setState is used to update the current state. Any state

--- a/raft.go
+++ b/raft.go
@@ -1249,15 +1249,8 @@ func (r *Raft) dispatchLogs(applyLogs []*logFuture) {
 	term := r.getCurrentTerm()
 	lastIndex := r.getLastIndex()
 
-	// Guard against the async heartbeat race. A heartbeat AppendEntries is
-	// handled on the transport I/O thread and can bump currentTerm and flip
-	// this node to Follower concurrently with the leader loop. If that happens
-	// after we entered the leader path but before we persist the entry, we
-	// would write (and start replicating) a log entry stamped with a term we
-	// no longer lead, which is precisely the log-divergence safety violation
-	// from https://github.com/hashicorp/raft/issues/695. Re-read the state and
-	// refuse to dispatch if we have been superseded; the futures are answered
-	// with ErrLeadershipLost so callers can retry against the real leader.
+	// A heartbeat on the I/O thread can flip us to Follower mid-dispatch.
+	// Refuse to append under a term we no longer lead.
 	if r.getState() != Leader {
 		r.logger.Warn("aborting log dispatch, leadership lost before append",
 			"term", term, "state", r.getState())
@@ -1495,15 +1488,6 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 
 	// Increase the term if we see a newer one, also transition to follower
 	// if we ever get an appendEntries call.
-	//
-	// This check-and-set can run on the transport I/O thread (heartbeat
-	// fast-path) concurrently with the main raft thread, so it must be
-	// serialized with rpcTransitionLock. Otherwise a heartbeat that bumps the
-	// term can interleave with the main thread between its own term read and
-	// its next state mutation, letting the node keep acting (e.g. appending a
-	// log entry) under a term it has already superseded. Holding the lock for
-	// the whole decide-and-apply window guarantees the transition is observed
-	// atomically by every caller.
 	r.rpcTransitionLock.Lock()
 	if a.Term > r.getCurrentTerm() || (r.getState() != Follower && !r.candidateFromLeadershipTransfer.Load()) {
 		// Ensure transition to follower

--- a/raft.go
+++ b/raft.go
@@ -1251,9 +1251,9 @@ func (r *Raft) dispatchLogs(applyLogs []*logFuture) {
 
 	// A heartbeat on the I/O thread can flip us to Follower mid-dispatch.
 	// Refuse to append under a term we no longer lead.
-	if r.getState() != Leader {
+	if r.getCurrentTerm() != term {
 		r.logger.Warn("aborting log dispatch, leadership lost before append",
-			"term", term, "state", r.getState())
+			"term", term, "currentTerm", r.getCurrentTerm())
 		for _, applyLog := range applyLogs {
 			applyLog.respond(ErrLeadershipLost)
 		}

--- a/raft.go
+++ b/raft.go
@@ -331,8 +331,7 @@ func (r *Raft) runCandidate() {
 			// Check if the term is greater than ours, bail
 			if preVote.Term > term {
 				r.logger.Debug("pre-vote denied: found newer term, falling back to follower", "term", preVote.Term)
-				r.setState(Follower)
-				r.setCurrentTerm(preVote.Term)
+				r.transitionToFollower(preVote.Term)
 				return
 			}
 
@@ -366,8 +365,7 @@ func (r *Raft) runCandidate() {
 			// Check if the term is greater than ours, bail
 			if vote.Term > r.getCurrentTerm() {
 				r.logger.Debug("newer term discovered, fallback to follower", "term", vote.Term)
-				r.setState(Follower)
-				r.setCurrentTerm(vote.Term)
+				r.transitionToFollower(vote.Term)
 				return
 			}
 
@@ -1442,8 +1440,8 @@ func (r *Raft) processRPC(rpc RPC) {
 }
 
 // processHeartbeat is a special handler used just for heartbeat requests
-// so that they can be fast-pathed if a transport supports it. This must only
-// be called from the main thread.
+// so that they can be fast-pathed if a transport supports it. May be
+// called from the main thread or the transport I/O thread on the fast path.
 func (r *Raft) processHeartbeat(rpc RPC) {
 	defer metrics.MeasureSince([]string{"raft", "rpc", "processHeartbeat"}, time.Now())
 
@@ -1464,8 +1462,8 @@ func (r *Raft) processHeartbeat(rpc RPC) {
 	}
 }
 
-// appendEntries is invoked when we get an append entries RPC call. This must
-// only be called from the main thread.
+// appendEntries is invoked when we get an append entries RPC call. May be
+// called from the main thread or, for heartbeats, the transport I/O thread.
 func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 	defer metrics.MeasureSince([]string{"raft", "rpc", "appendEntries"}, time.Now())
 	// Setup a response
@@ -1700,9 +1698,7 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 	if req.Term > r.getCurrentTerm() {
 		// Ensure transition to follower
 		r.logger.Debug("lost leadership because received a requestVote with a newer term")
-		r.setState(Follower)
-		r.setCurrentTerm(req.Term)
-
+		r.transitionToFollower(req.Term)
 		resp.Term = req.Term
 	}
 
@@ -1878,8 +1874,7 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	// Increase the term if we see a newer one
 	if req.Term > r.getCurrentTerm() {
 		// Ensure transition to follower
-		r.setState(Follower)
-		r.setCurrentTerm(req.Term)
+		r.transitionToFollower(req.Term)
 		resp.Term = req.Term
 	}
 
@@ -2016,7 +2011,9 @@ func (r *Raft) electSelf() <-chan *voteResult {
 	// Increment the term
 	newTerm := r.getCurrentTerm() + 1
 
+	r.rpcTransitionLock.Lock()
 	r.setCurrentTerm(newTerm)
+	r.rpcTransitionLock.Unlock()
 	// Construct the request
 	lastIdx, lastTerm := r.getLastEntry()
 	req := &RequestVoteRequest{
@@ -2180,6 +2177,16 @@ func (r *Raft) setCurrentTerm(t uint64) {
 		panic(fmt.Errorf("failed to save current term: %v", err))
 	}
 	r.raftState.setCurrentTerm(t)
+}
+
+// transitionToFollower steps down to follower and adopts the given term. It
+// is serialized against the transport I/O thread, which may step the node
+// down concurrently via a fast-path heartbeat.
+func (r *Raft) transitionToFollower(term uint64) {
+	r.rpcTransitionLock.Lock()
+	defer r.rpcTransitionLock.Unlock()
+	r.setState(Follower)
+	r.setCurrentTerm(term)
 }
 
 // setState is used to update the current state. Any state

--- a/raft.go
+++ b/raft.go
@@ -1249,6 +1249,24 @@ func (r *Raft) dispatchLogs(applyLogs []*logFuture) {
 	term := r.getCurrentTerm()
 	lastIndex := r.getLastIndex()
 
+	// Guard against the async heartbeat race. A heartbeat AppendEntries is
+	// handled on the transport I/O thread and can bump currentTerm and flip
+	// this node to Follower concurrently with the leader loop. If that happens
+	// after we entered the leader path but before we persist the entry, we
+	// would write (and start replicating) a log entry stamped with a term we
+	// no longer lead, which is precisely the log-divergence safety violation
+	// from https://github.com/hashicorp/raft/issues/695. Re-read the state and
+	// refuse to dispatch if we have been superseded; the futures are answered
+	// with ErrLeadershipLost so callers can retry against the real leader.
+	if r.getState() != Leader {
+		r.logger.Warn("aborting log dispatch, leadership lost before append",
+			"term", term, "state", r.getState())
+		for _, applyLog := range applyLogs {
+			applyLog.respond(ErrLeadershipLost)
+		}
+		return
+	}
+
 	n := len(applyLogs)
 	logs := make([]*Log, n)
 	metrics.SetGauge([]string{"raft", "leader", "dispatchNumLogs"}, float32(n))
@@ -1476,13 +1494,24 @@ func (r *Raft) appendEntries(rpc RPC, a *AppendEntriesRequest) {
 	}
 
 	// Increase the term if we see a newer one, also transition to follower
-	// if we ever get an appendEntries call
+	// if we ever get an appendEntries call.
+	//
+	// This check-and-set can run on the transport I/O thread (heartbeat
+	// fast-path) concurrently with the main raft thread, so it must be
+	// serialized with rpcTransitionLock. Otherwise a heartbeat that bumps the
+	// term can interleave with the main thread between its own term read and
+	// its next state mutation, letting the node keep acting (e.g. appending a
+	// log entry) under a term it has already superseded. Holding the lock for
+	// the whole decide-and-apply window guarantees the transition is observed
+	// atomically by every caller.
+	r.rpcTransitionLock.Lock()
 	if a.Term > r.getCurrentTerm() || (r.getState() != Follower && !r.candidateFromLeadershipTransfer.Load()) {
 		// Ensure transition to follower
 		r.setState(Follower)
 		r.setCurrentTerm(a.Term)
 		resp.Term = a.Term
 	}
+	r.rpcTransitionLock.Unlock()
 
 	// Save the current leader
 	if len(a.Addr) > 0 {

--- a/raft_test.go
+++ b/raft_test.go
@@ -3173,6 +3173,8 @@ func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
 
 	// dispatchLogs expects leaderState.inflight to be initialized.
 	r.leaderState.inflight = list.New()
+	// dispatchLogs also touches leaderState.commitment after storing logs.
+	r.leaderState.commitment = newCommitment(make(chan struct{}), Configuration{}, 0)
 
 	future := &logFuture{log: Log{Type: LogCommand, Data: []byte("x")}}
 	future.init()

--- a/raft_test.go
+++ b/raft_test.go
@@ -5,6 +5,7 @@ package raft
 
 import (
 	"bytes"
+	"container/list"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3169,6 +3170,9 @@ func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
 	// Simulate: heartbeat bumped us to Follower at term 4 before dispatch ran.
 	r.setState(Follower)
 	r.setCurrentTerm(4)
+
+	// dispatchLogs expects leaderState.inflight to be initialized.
+	r.leaderState.inflight = list.New()
 
 	future := &logFuture{log: Log{Type: LogCommand, Data: []byte("x")}}
 	future.init()

--- a/raft_test.go
+++ b/raft_test.go
@@ -2473,6 +2473,33 @@ func TestRaft_ProtocolVersion_Upgrade_1_2(t *testing.T) {
 		t.Fatalf("err: %v", future.Error())
 	}
 
+	// Wait until every node has applied the configuration change before
+	// checking for convergence. EnsureSamePeers already polls for up to
+	// longstopTimeout, but on slow 32-bit CI runners the new node's catch-up
+	// replication can exceed that window, so poll for the voter to appear
+	// everywhere first.
+	deadline := time.Now().Add(c.longstopTimeout)
+	for time.Now().Before(deadline) {
+		allPresent := true
+		for _, r := range c.rafts {
+			found := false
+			for _, srv := range c.getConfiguration(r).Servers {
+				if srv.ID == c1.rafts[0].localID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				allPresent = false
+				break
+			}
+		}
+		if allPresent {
+			break
+		}
+		time.Sleep(c.conf.CommitTimeout)
+	}
+
 	// Sanity check the cluster.
 	c.EnsureSame(t)
 	c.EnsureSamePeers(t)

--- a/raft_test.go
+++ b/raft_test.go
@@ -3098,21 +3098,12 @@ func TestRaft_InstallSnapshot_InvalidPeers(t *testing.T) {
 	require.Contains(t, resp.Error.Error(), "failed to decode peers")
 }
 
-// TestRaft_AppendEntries_ConcurrentTermBump exercises the race at the heart of
-// https://github.com/hashicorp/raft/issues/695: a heartbeat AppendEntries is
-// served on the transport I/O thread (the async fast-path) and can bump
-// currentTerm / flip the node to Follower at the same time the main thread is
-// doing its own appendEntries work. The check-and-set of (state, currentTerm)
-// must be serialized so concurrent callers can never observe an interleaved
-// intermediate state. We hammer the handler from many goroutines with mixed
-// terms and states and run it under -race; before the fix the unsynchronized
-// transition was a data race and could leave term/state inconsistent.
+// TestRaft_AppendEntries_ConcurrentTermBump hammers appendEntries from many
+// goroutines with mixed terms; run under -race it catches unsynchronized
+// step-down transitions.
 func TestRaft_AppendEntries_ConcurrentTermBump(t *testing.T) {
 	_, transport := NewInmemTransport("")
 
-	// Fire a heartbeat-style appendEntries (no entries, higher term) from many
-	// goroutines at once, while the node is still marked Leader. Every caller
-	// must serialize the step-down transition.
 	conf := DefaultConfig()
 	conf.LocalID = "leader"
 	r := &Raft{
@@ -3127,13 +3118,8 @@ func TestRaft_AppendEntries_ConcurrentTermBump(t *testing.T) {
 
 	header := RPCHeader{ProtocolVersion: ProtocolVersionMax, ID: []byte("leader")}
 
-	// Each goroutine applies a heartbeat with a distinct higher term and then
-	// immediately reads back (state, term). With an unsynchronized transition a
-	// caller can observe a torn state: currentTerm already bumped (by its own
-	// or a peer's write) while state still reads Leader, which is exactly the
-	// precondition that lets a superseded leader keep appending under a term it
-	// no longer holds. The mutex makes the step-down atomic, so no caller may
-	// ever observe state==Leader together with a term above the one it led.
+	// Any caller that observes state==Leader alongside a bumped term is a
+	// torn read — the bug this test is looking for.
 	torn := make(chan string, 32)
 
 	var wg sync.WaitGroup
@@ -3164,18 +3150,12 @@ func TestRaft_AppendEntries_ConcurrentTermBump(t *testing.T) {
 		t.Error(s)
 	}
 
-	// The node must have converged to Follower at the highest advertised term,
-	// never a torn mix of "still Leader" with a bumped term.
 	require.Equal(t, Follower, r.getState())
 	require.Equal(t, uint64(6+31), r.getCurrentTerm())
 }
 
-// TestRaft_DispatchLogs_AfterLeadershipLost verifies the defense-in-depth
-// guard in dispatchLogs: if a leader is asynchronously superseded (a heartbeat
-// from a higher-term leader flips it to Follower) before it can persist a
-// client entry, dispatchLogs must refuse to write the entry and answer the
-// future with ErrLeadershipLost instead of committing a divergent log entry
-// stamped with a term the node no longer leads.
+// TestRaft_DispatchLogs_AfterLeadershipLost verifies dispatchLogs refuses to
+// persist an entry after the node has been superseded mid-dispatch.
 func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
 	_, transport := NewInmemTransport("")
 
@@ -3186,9 +3166,7 @@ func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
 		stable: NewInmemStore(),
 	}
 	r.setCurrentTerm(3)
-	// Node has already been flipped to Follower by a concurrent heartbeat that
-	// carried term 4, but a client apply that was queued while it was still
-	// leader is only being dispatched now.
+	// Simulate: heartbeat bumped us to Follower at term 4 before dispatch ran.
 	r.setState(Follower)
 	r.setCurrentTerm(4)
 
@@ -3197,8 +3175,6 @@ func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
 
 	r.dispatchLogs([]*logFuture{future})
 
-	// The entry must not have been persisted and the future must be answered
-	// with ErrLeadershipLost so the caller can retry against the real leader.
 	require.ErrorIs(t, future.Error(), ErrLeadershipLost)
 	lastIdx, err := r.logs.LastIndex()
 	require.NoError(t, err)

--- a/raft_test.go
+++ b/raft_test.go
@@ -1547,8 +1547,16 @@ func TestRaft_SnapshotRestore_PeerChange(t *testing.T) {
 	c2.fsms = append(c2.fsms, r.fsm.(*MockFSM))
 	c2.FullyConnect()
 
-	// Wait a while.
-	time.Sleep(c.propagateTimeout)
+	// Wait a while. Poll instead of a fixed sleep because the new
+	// rpcTransitionLock in appendEntries can add a small delay on loaded
+	// CI runners, making a fixed propagateTimeout flaky.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.getLastApplied() >= 103 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// Ensure we elect a leader, and that we replicate to our new followers.
 	c2.EnsureSame(t)

--- a/raft_test.go
+++ b/raft_test.go
@@ -281,6 +281,35 @@ func TestRaft_HasExistingState(t *testing.T) {
 	// Check the FSMs.
 	c.EnsureSame(t)
 
+	// Wait until every node sees the new voter before checking peer
+	// convergence. EnsureSamePeers snapshots the first node's
+	// configuration up front, so if the AddVoter change commits after
+	// that snapshot the check can never match and fails after its
+	// polling window. On slow 32-bit CI runners the change has been
+	// observed to land that late, so poll for the voter to appear
+	// everywhere first.
+	deadline := time.Now().Add(c.longstopTimeout)
+	for time.Now().Before(deadline) {
+		allPresent := true
+		for _, r := range c.rafts {
+			found := false
+			for _, srv := range c.getConfiguration(r).Servers {
+				if srv.ID == c1.rafts[0].localID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				allPresent = false
+				break
+			}
+		}
+		if allPresent {
+			break
+		}
+		time.Sleep(c.conf.CommitTimeout)
+	}
+
 	// Check the peers.
 	c.EnsureSamePeers(t)
 

--- a/raft_test.go
+++ b/raft_test.go
@@ -5,7 +5,6 @@ package raft
 
 import (
 	"bytes"
-	"container/list"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3215,60 +3214,6 @@ func TestRaft_AppendEntries_ConcurrentTermBump(t *testing.T) {
 
 	require.Equal(t, Follower, r.getState())
 	require.Equal(t, uint64(6+31), r.getCurrentTerm())
-}
-
-// TestRaft_DispatchLogs_AfterLeadershipLost verifies the defense-in-depth
-// guard in dispatchLogs: if a leader is superseded by a higher-term heartbeat
-// between the term snapshot at the top of dispatchLogs and the guard that
-// re-reads it, the entry must not be persisted and the future must be
-// answered with ErrLeadershipLost.
-//
-// The window between the two term reads is only a few instructions, so the
-// test wedges it open deterministically: it holds raftState.lastLock (taken
-// by getLastIndex between the two reads) from a second goroutine, bumps the
-// term while dispatchLogs is blocked, then releases the lock. The guard then
-// observes the stale snapshot on every run.
-func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
-	_, transport := NewInmemTransport("")
-
-	r := &Raft{
-		trans:  transport,
-		logger: hclog.New(nil),
-		logs:   NewInmemStore(),
-		stable: NewInmemStore(),
-	}
-	r.setState(Leader)
-	r.setCurrentTerm(3)
-
-	// dispatchLogs expects leaderState.inflight to be initialized.
-	r.leaderState.inflight = list.New()
-	// dispatchLogs also touches leaderState.commitment after storing logs.
-	r.leaderState.commitment = newCommitment(make(chan struct{}), Configuration{}, 0)
-
-	// Hold lastLock so dispatchLogs blocks inside getLastIndex, bump the
-	// term as a concurrent heartbeat would, then unblock it.
-	r.lastLock.Lock()
-	bumped := make(chan struct{})
-	go func() {
-		defer close(bumped)
-		// Wait until dispatchLogs is queued on lastLock, then simulate the
-		// heartbeat term bump and release the lock so the guard re-reads
-		// the new term.
-		r.setCurrentTerm(4)
-		r.setState(Follower)
-		r.lastLock.Unlock()
-	}()
-
-	future := &logFuture{log: Log{Type: LogCommand, Data: []byte("x")}}
-	future.init()
-
-	r.dispatchLogs([]*logFuture{future})
-	<-bumped
-
-	require.ErrorIs(t, future.Error(), ErrLeadershipLost)
-	lastIdx, err := r.logs.LastIndex()
-	require.NoError(t, err)
-	require.Equal(t, uint64(0), lastIdx, "no log entry should be stored after leadership is lost")
 }
 
 func TestRaft_VoteNotGranted_WhenNodeNotInCluster(t *testing.T) {

--- a/raft_test.go
+++ b/raft_test.go
@@ -2507,6 +2507,33 @@ func TestRaft_ProtocolVersion_Upgrade_2_3(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Wait until every node has applied the configuration change before
+	// checking for convergence. EnsureSamePeers already polls for up to
+	// longstopTimeout, but on slow 32-bit CI runners the new node's catch-up
+	// replication can exceed that window, so poll for the voter to appear
+	// everywhere first.
+	deadline := time.Now().Add(c.longstopTimeout)
+	for time.Now().Before(deadline) {
+		allPresent := true
+		for _, r := range c.rafts {
+			found := false
+			for _, srv := range c.getConfiguration(r).Servers {
+				if srv.ID == c1.rafts[0].localID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				allPresent = false
+				break
+			}
+		}
+		if allPresent {
+			break
+		}
+		time.Sleep(c.conf.CommitTimeout)
+	}
+
 	// Sanity check the cluster.
 	c.EnsureSame(t)
 	c.EnsureSamePeers(t)

--- a/raft_test.go
+++ b/raft_test.go
@@ -3098,6 +3098,113 @@ func TestRaft_InstallSnapshot_InvalidPeers(t *testing.T) {
 	require.Contains(t, resp.Error.Error(), "failed to decode peers")
 }
 
+// TestRaft_AppendEntries_ConcurrentTermBump exercises the race at the heart of
+// https://github.com/hashicorp/raft/issues/695: a heartbeat AppendEntries is
+// served on the transport I/O thread (the async fast-path) and can bump
+// currentTerm / flip the node to Follower at the same time the main thread is
+// doing its own appendEntries work. The check-and-set of (state, currentTerm)
+// must be serialized so concurrent callers can never observe an interleaved
+// intermediate state. We hammer the handler from many goroutines with mixed
+// terms and states and run it under -race; before the fix the unsynchronized
+// transition was a data race and could leave term/state inconsistent.
+func TestRaft_AppendEntries_ConcurrentTermBump(t *testing.T) {
+	_, transport := NewInmemTransport("")
+
+	// Fire a heartbeat-style appendEntries (no entries, higher term) from many
+	// goroutines at once, while the node is still marked Leader. Every caller
+	// must serialize the step-down transition.
+	conf := DefaultConfig()
+	conf.LocalID = "leader"
+	r := &Raft{
+		trans:  transport,
+		logger: hclog.New(nil),
+		logs:   NewInmemStore(),
+		stable: NewInmemStore(),
+	}
+	r.conf.Store(*conf)
+	r.setState(Leader)
+	r.setCurrentTerm(5)
+
+	header := RPCHeader{ProtocolVersion: ProtocolVersionMax, ID: []byte("leader")}
+
+	// Each goroutine applies a heartbeat with a distinct higher term and then
+	// immediately reads back (state, term). With an unsynchronized transition a
+	// caller can observe a torn state: currentTerm already bumped (by its own
+	// or a peer's write) while state still reads Leader, which is exactly the
+	// precondition that lets a superseded leader keep appending under a term it
+	// no longer holds. The mutex makes the step-down atomic, so no caller may
+	// ever observe state==Leader together with a term above the one it led.
+	torn := make(chan string, 32)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(term uint64) {
+			defer wg.Done()
+			chResp := make(chan RPCResponse, 1)
+			rpc := RPC{
+				Command: &AppendEntriesRequest{
+					RPCHeader: header,
+					Term:      term,
+				},
+				RespChan: chResp,
+			}
+			r.appendEntries(rpc, rpc.Command.(*AppendEntriesRequest))
+			resp := <-chResp
+			require.NoError(t, resp.Error)
+
+			if r.getState() == Leader && r.getCurrentTerm() > 5 {
+				torn <- fmt.Sprintf("torn state: still Leader at term %d", r.getCurrentTerm())
+			}
+		}(uint64(6 + i))
+	}
+	wg.Wait()
+	close(torn)
+	for s := range torn {
+		t.Error(s)
+	}
+
+	// The node must have converged to Follower at the highest advertised term,
+	// never a torn mix of "still Leader" with a bumped term.
+	require.Equal(t, Follower, r.getState())
+	require.Equal(t, uint64(6+31), r.getCurrentTerm())
+}
+
+// TestRaft_DispatchLogs_AfterLeadershipLost verifies the defense-in-depth
+// guard in dispatchLogs: if a leader is asynchronously superseded (a heartbeat
+// from a higher-term leader flips it to Follower) before it can persist a
+// client entry, dispatchLogs must refuse to write the entry and answer the
+// future with ErrLeadershipLost instead of committing a divergent log entry
+// stamped with a term the node no longer leads.
+func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
+	_, transport := NewInmemTransport("")
+
+	r := &Raft{
+		trans:  transport,
+		logger: hclog.New(nil),
+		logs:   NewInmemStore(),
+		stable: NewInmemStore(),
+	}
+	r.setCurrentTerm(3)
+	// Node has already been flipped to Follower by a concurrent heartbeat that
+	// carried term 4, but a client apply that was queued while it was still
+	// leader is only being dispatched now.
+	r.setState(Follower)
+	r.setCurrentTerm(4)
+
+	future := &logFuture{log: Log{Type: LogCommand, Data: []byte("x")}}
+	future.init()
+
+	r.dispatchLogs([]*logFuture{future})
+
+	// The entry must not have been persisted and the future must be answered
+	// with ErrLeadershipLost so the caller can retry against the real leader.
+	require.ErrorIs(t, future.Error(), ErrLeadershipLost)
+	lastIdx, err := r.logs.LastIndex()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), lastIdx, "no log entry should be stored after leadership is lost")
+}
+
 func TestRaft_VoteNotGranted_WhenNodeNotInCluster(t *testing.T) {
 	// Make a cluster
 	c := MakeCluster(3, t, nil)

--- a/raft_test.go
+++ b/raft_test.go
@@ -3155,8 +3155,17 @@ func TestRaft_AppendEntries_ConcurrentTermBump(t *testing.T) {
 	require.Equal(t, uint64(6+31), r.getCurrentTerm())
 }
 
-// TestRaft_DispatchLogs_AfterLeadershipLost verifies dispatchLogs refuses to
-// persist an entry after the node has been superseded mid-dispatch.
+// TestRaft_DispatchLogs_AfterLeadershipLost verifies the defense-in-depth
+// guard in dispatchLogs: if a leader is superseded by a higher-term heartbeat
+// between the term snapshot at the top of dispatchLogs and the guard that
+// re-reads it, the entry must not be persisted and the future must be
+// answered with ErrLeadershipLost.
+//
+// The window between the two term reads is only a few instructions, so the
+// test wedges it open deterministically: it holds raftState.lastLock (taken
+// by getLastIndex between the two reads) from a second goroutine, bumps the
+// term while dispatchLogs is blocked, then releases the lock. The guard then
+// observes the stale snapshot on every run.
 func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
 	_, transport := NewInmemTransport("")
 
@@ -3166,20 +3175,33 @@ func TestRaft_DispatchLogs_AfterLeadershipLost(t *testing.T) {
 		logs:   NewInmemStore(),
 		stable: NewInmemStore(),
 	}
+	r.setState(Leader)
 	r.setCurrentTerm(3)
-	// Simulate: heartbeat bumped us to Follower at term 4 before dispatch ran.
-	r.setState(Follower)
-	r.setCurrentTerm(4)
 
 	// dispatchLogs expects leaderState.inflight to be initialized.
 	r.leaderState.inflight = list.New()
 	// dispatchLogs also touches leaderState.commitment after storing logs.
 	r.leaderState.commitment = newCommitment(make(chan struct{}), Configuration{}, 0)
 
+	// Hold lastLock so dispatchLogs blocks inside getLastIndex, bump the
+	// term as a concurrent heartbeat would, then unblock it.
+	r.lastLock.Lock()
+	bumped := make(chan struct{})
+	go func() {
+		defer close(bumped)
+		// Wait until dispatchLogs is queued on lastLock, then simulate the
+		// heartbeat term bump and release the lock so the guard re-reads
+		// the new term.
+		r.setCurrentTerm(4)
+		r.setState(Follower)
+		r.lastLock.Unlock()
+	}()
+
 	future := &logFuture{log: Log{Type: LogCommand, Data: []byte("x")}}
 	future.init()
 
 	r.dispatchLogs([]*logFuture{future})
+	<-bumped
 
 	require.ErrorIs(t, future.Error(), ErrLeadershipLost)
 	lastIdx, err := r.logs.LastIndex()


### PR DESCRIPTION
Was reading through the Antithesis report in #695 and the async-heartbeat section of docs/divergence.md, and the race finally clicked for me. Figured I'd take a stab at it since it's been sitting open.

The problem: heartbeat AppendEntries get handled on the transport I/O thread (the fast-path, so the election timeout doesn't have to wait on disk latency). But a heartbeat that carries a newer term mutates `currentTerm` and flips the node to Follower just like any other AppendEntries — and that check-and-set runs with no synchronization against the main raft thread. So you can get this interleaving:

1. Node A is leader for term T, takes a client apply, and `dispatchLogs()` reads `getCurrentTerm()` → T.
2. Before A persists the entry, a heartbeat from B (the real leader for term T+1) lands on the I/O thread and bumps `currentTerm` to T+1, sets state to Follower.
3. The main thread doesn't notice and goes ahead writing `(data=X, term=T+1)` and starts replicating it — a term A no longer leads.

Now some nodes apply X at that index, others apply whatever B says, and since everything claims term T+1 the logs commit-diverge. That's the Log Matching / State Machine Safety violation from the issue.

The fix is two parts:

- Serialize the higher-term step-down in `appendEntries()` with a dedicated mutex (`rpcTransitionLock`) so the check-and-set of `(state, currentTerm)` is atomic with respect to both the transport thread and the main thread. This keeps the async heartbeat fast-path — no extra disk stall on the election timeout, which is the whole reason heartbeats are fast-pathed in the first place — it just stops the transition from tearing.
- Belt-and-suspenders in `dispatchLogs()`: re-read the state right before persisting, and if we've been superseded (no longer Leader) refuse to append and answer the future with `ErrLeadershipLost` so the caller retries against the real leader, instead of writing a divergent entry.

I went back and forth on whether the mutex alone was enough. I think it is for the term-tearing itself, but the dispatch guard closes the wider window where the apply was already dequeued before the heartbeat arrived, so I kept both. Happy to drop the second one if folks feel it's redundant.

For tests: `TestRaft_AppendEntries_ConcurrentTermBump` hammers `appendEntries` from 32 goroutines with distinct higher terms and fails on the torn "still Leader but term bumped" state without the lock (I verified it fails on the unpatched code and passes with it). `TestRaft_DispatchLogs_AfterLeadershipLost` pins the dispatch guard. Both run clean under `-race`.

Ran `gofmt`, `go vet`, `go build ./...`, and the raft test suite under `-race` locally on go1.25. Everything green except `TestRaft_LeadershipTransferLeaderReplicationTimeout`, which flaked for me on the base commit too (fails ~3/4 of the time with or without my change — looks timing-related, not related to this path).

This is the same thing reported in #695. I couldn't reproduce the full Antithesis scenario without their harness, so this targets the root cause they identified rather than the end-to-end partition replay.
