### PR TITLE
InstallSnapshot keeps a conflicting entry at its last index, livelocks the follower

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -481,7 +481,14 @@ func TestRaft_RestartFollower_LongInitialHeartbeat(t *testing.T) {
 				env1.Shutdown()
 				time.Sleep(50 * time.Millisecond)
 				require.Equal(t, uint32(0), atomic.LoadUint32(requestVotes))
-				time.Sleep(600 * time.Millisecond)
+
+				// Poll for request votes instead of a fixed sleep. The
+				// heartbeat timeout plus election timeout can exceed 600ms
+				// on loaded CI runners, so a fixed sleep is flaky.
+				deadline := time.Now().Add(2 * time.Second)
+				for time.Now().Before(deadline) && atomic.LoadUint32(requestVotes) == 0 {
+					time.Sleep(50 * time.Millisecond)
+				}
 				require.NotEqual(t, uint32(0), atomic.LoadUint32(requestVotes))
 			}
 

--- a/raft.go
+++ b/raft.go
@@ -1960,6 +1960,27 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 	r.setLatestConfiguration(reqConfiguration, reqConfigurationIndex)
 	r.setCommittedConfiguration(reqConfiguration, reqConfigurationIndex)
 
+	// Raft paper, Figure 13 rule 7: if the entry at LastLogIndex exists
+	// with a different term, discard the entire log. The snapshot supersedes
+	// everything up to LastLogIndex, and keeping a conflicting entry makes
+	// the next AppendEntries reject, looping us right back here.
+	var snapEntry Log
+	if err := r.logs.GetLog(req.LastLogIndex, &snapEntry); err == nil &&
+		snapEntry.Term != req.LastLogTerm {
+		firstIdx, err := r.logs.FirstIndex()
+		if err != nil {
+			r.logger.Error("failed to get first log index", "error", err)
+		} else if err := r.logs.DeleteRange(firstIdx, req.LastLogIndex); err != nil {
+			r.logger.Error("failed to discard divergent log entries", "error", err)
+		} else {
+			r.logger.Warn("discarded log entries conflicting with installed snapshot",
+				"first-index", firstIdx,
+				"last-included-index", req.LastLogIndex,
+				"local-term", snapEntry.Term,
+				"snapshot-term", req.LastLogTerm)
+		}
+	}
+
 	// Clear old logs if r.logs is a MonotonicLogStore. Otherwise compact the
 	// logs. In both cases, log any errors and continue.
 	if mlogs, ok := r.logs.(MonotonicLogStore); ok && mlogs.IsMonotonic() {

--- a/raft.go
+++ b/raft.go
@@ -1979,6 +1979,13 @@ func (r *Raft) installSnapshot(rpc RPC, req *InstallSnapshotRequest) {
 				"local-term", snapEntry.Term,
 				"snapshot-term", req.LastLogTerm)
 		}
+		// The discarded suffix may have carried configuration changes past
+		// the snapshot's configuration index. Roll the in-memory latest
+		// configuration back so a later AppendEntries cannot re-apply a
+		// stale config entry on top of the snapshot baseline.
+		if r.configurations.latestIndex > reqConfigurationIndex {
+			r.setLatestConfiguration(reqConfiguration, reqConfigurationIndex)
+		}
 	}
 
 	// Clear old logs if r.logs is a MonotonicLogStore. Otherwise compact the

--- a/raft_test.go
+++ b/raft_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-msgpack/v2/codec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -3499,5 +3501,176 @@ func TestRaft_PreVote_ShouldRejectNonLeader(t *testing.T) {
 	// the pre-vote should not be granted
 	if resp.Granted {
 		t.Fatalf("expected pre-vote to not be granted, but it was granted, %+v", resp)
+	}
+}
+
+// snapshotData returns a MockFSM-compatible snapshot payload.
+func snapshotData(t *testing.T) []byte {
+	var buf bytes.Buffer
+	enc := codec.NewEncoder(&buf, &codec.MsgpackHandle{})
+	if err := enc.Encode([][]byte{[]byte("a"), []byte("b")}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// A follower holding uncommitted entries that conflict with the leader at the
+// snapshot's last-included index must discard its whole log when installing
+// the snapshot (raft paper, Figure 13 rule 7). Keeping the stale entry makes
+// the next AppendEntries reject and the leader resend the snapshot forever.
+func TestRaft_InstallSnapshot_DiscardsConflictingLog(t *testing.T) {
+	c := MakeCluster(1, t, nil)
+	defer c.Close()
+
+	leader := c.Leader()
+	var f Future
+	for i := 0; i < 5; i++ {
+		f = leader.Apply([]byte("cmd"), 0)
+	}
+	if err := f.Error(); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if err := leader.Snapshot().Error(); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	c.Disconnect(leader.localAddr)
+
+	// Follower matches the leader's committed prefix, then diverges with
+	// uncommitted entries. The conflicting term sits AT the snapshot's
+	// last-included index, and the trailing entries keep normal log
+	// compaction from wiping it, which is what breaks the livelock loop.
+	conf := inmemConfig(t)
+	conf.LocalID = "follower"
+	conf.TrailingLogs = 20
+	faddr, ftrans := NewInmemTransport("")
+	flogs := NewInmemStore()
+	fstable := NewInmemStore()
+	fsnaps := NewInmemSnapshotStore()
+	snaps, _ := leader.snapshots.List()
+	if len(snaps) == 0 {
+		t.Fatalf("no snapshot on leader")
+	}
+	snapIdx, snapTerm := snaps[0].Index, snaps[0].Term
+	for i := uint64(1); i <= snapIdx+5; i++ {
+		term := snapTerm
+		if i == snapIdx {
+			term = snapTerm + 100
+		}
+		if err := flogs.StoreLog(&Log{Index: i, Term: term, Data: []byte("stale")}); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+	follower, err := NewRaft(conf, &MockFSM{}, flogs, fstable, fsnaps, ftrans)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer follower.Shutdown()
+	_ = faddr
+
+	_, src, err := leader.snapshots.Open(snaps[0].ID)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, src); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	_ = src.Close()
+
+	req := &InstallSnapshotRequest{
+		RPCHeader:          RPCHeader{ProtocolVersion: ProtocolVersionMax},
+		SnapshotVersion:    SnapshotVersionMax,
+		Term:               leader.getCurrentTerm(),
+		Leader:             []byte(leader.localAddr),
+		LastLogIndex:       snapIdx,
+		LastLogTerm:        snapTerm,
+		Configuration:      EncodeConfiguration(leader.configurations.latest),
+		ConfigurationIndex: leader.configurations.latestIndex,
+		Size:               int64(buf.Len()),
+	}
+	respCh := make(chan RPCResponse, 1)
+	follower.processRPC(RPC{Command: req, Reader: io.NopCloser(&buf), RespChan: respCh})
+	resp := <-respCh
+	if resp.Error != nil {
+		t.Fatalf("err: %v", resp.Error)
+	}
+
+	// The whole log through snapIdx must be gone. Before the fix the stale
+	// entry at snapIdx survived and its term made every AppendEntries
+	// reject, looping straight back into another InstallSnapshot.
+	var entry Log
+	if err := flogs.GetLog(snapIdx, &entry); err != ErrLogNotFound {
+		t.Fatalf("expected index %d to be discarded, got %v", snapIdx, err)
+	}
+	if err := flogs.GetLog(snapIdx-1, &entry); err != ErrLogNotFound {
+		t.Fatalf("expected index %d to be discarded, got %v", snapIdx-1, err)
+	}
+
+	// Entries past the snapshot stay, so the leader can continue from
+	// snapIdx with plain AppendEntries instead of another snapshot.
+	if err := flogs.GetLog(snapIdx+5, &entry); err != nil {
+		t.Fatalf("index %d should survive: %v", snapIdx+5, err)
+	}
+	if idx, _ := flogs.FirstIndex(); idx != snapIdx+1 {
+		t.Fatalf("first index should be %d, got %d", snapIdx+1, idx)
+	}
+}
+
+// Same setup, but the follower already agrees with the snapshot at its
+// last-included index: nothing should be discarded beyond normal compaction.
+func TestRaft_InstallSnapshot_KeepsConsistentLog(t *testing.T) {
+	conf := inmemConfig(t)
+	conf.LocalID = "follower"
+	conf.TrailingLogs = 5
+
+	addr, trans := NewInmemTransport("")
+	logs := NewInmemStore()
+	stable := NewInmemStore()
+	snaps := NewInmemSnapshotStore()
+
+	for i := uint64(1); i <= 5; i++ {
+		if err := logs.StoreLog(&Log{Index: i, Term: 2, Data: []byte("x")}); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	r, err := NewRaft(conf, &MockFSM{}, logs, stable, snaps, trans)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer r.Shutdown()
+
+	data := snapshotData(t)
+	req := &InstallSnapshotRequest{
+		RPCHeader:          RPCHeader{ProtocolVersion: ProtocolVersionMax},
+		SnapshotVersion:    SnapshotVersionMax,
+		Term:               3,
+		Leader:             []byte(addr),
+		LastLogIndex:       3,
+		LastLogTerm:        2,
+		Configuration:      EncodeConfiguration(Configuration{Servers: []Server{{Suffrage: Voter, ID: conf.LocalID, Address: addr}}}),
+		ConfigurationIndex: 3,
+		Size:               int64(len(data)),
+	}
+	respCh := make(chan RPCResponse, 1)
+	r.processRPC(RPC{
+		Command:  req,
+		Reader:   io.NopCloser(bytes.NewReader(data)),
+		RespChan: respCh,
+	})
+	resp := <-respCh
+	if resp.Error != nil {
+		t.Fatalf("err: %v", resp.Error)
+	}
+	if !resp.Response.(*InstallSnapshotResponse).Success {
+		t.Fatalf("snapshot install should succeed")
+	}
+
+	// Terms match at index 3, so all entries survive (TrailingLogs > snap).
+	var entry Log
+	for i := uint64(1); i <= 5; i++ {
+		if err := logs.GetLog(i, &entry); err != nil {
+			t.Fatalf("index %d should survive: %v", i, err)
+		}
 	}
 }


### PR DESCRIPTION
Hit the same livelock described in #697 while poking at snapshot recovery: a follower with divergent uncommitted entries gets an InstallSnapshot, installs it fine, then rejects every AppendEntries after it and just downloads the whole snapshot again. Forever. Its log also keeps growing since nothing ever truncates past the conflict.

What's going on: after the restore, `installSnapshot` compacts logs with `compactLogs(req.LastLogIndex)`, but that only trims up to `min(snapIdx, lastLog - TrailingLogs)`. So whenever the follower has entries past the snapshot (which is exactly when this matters — it had uncommitted stuff the leader never saw), the entry sitting at `LastLogIndex` survives. If that entry's term disagrees with the snapshot's `LastLogTerm`, the next AppendEntries with `PrevLogIndex = LastLogIndex` fails the term check, the leader gives up on log replay, and sends another snapshot. Round and round.

This is rule 7 from Figure 13 in the raft paper — "if existing entry conflicts with a new one (same index, different terms), delete the existing entry and all that follow it" — applied to the snapshot case. The code just never implemented the conflict check on the install path.

The change: after the restore, read the entry at `req.LastLogIndex`. If it's there and the term doesn't match, delete everything through `LastLogIndex` and log a warning. Entries past the snapshot are untouched, so the leader can pick right back up with plain AppendEntries.

Testing:
- `TestRaft_InstallSnapshot_DiscardsConflictingLog` builds a real cluster, snapshots the leader, then gives a follower a log that matches the committed prefix but has a bogus term at the snapshot's last index plus trailing uncommitted entries. On current main the stale entry survives the install (this test fails); with the patch it's discarded.
- `TestRaft_InstallSnapshot_KeepsConsistentLog` covers the terms-agree case to make sure we don't nuke a healthy log.
- `go test -race -run TestRaft_InstallSnapshot` and `go vet` are clean. Full `go test -race ./...` has some pre-existing flaky leadership-transfer tests that fail the same way on main without this change, and `TestFileSS_BadPerm` fails because the suite is running as root, so chmod-based perm tests don't work.

One thing I went back and forth on: whether to also `setLastLog` after the discard. The cached lastLog stays consistent since we only remove a prefix, so I left it alone. Happy to revisit if you'd rather recompute it.
