### PR TITLE
fix: stop leadership transfer when leader steps down

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1000,7 +1000,12 @@ func (r *Raft) leadershipTransfer(id ServerID, address ServerAddress, repl *foll
 	for atomic.LoadUint64(&repl.nextIndex) <= r.getLastIndex() {
 		err := &deferError{}
 		err.init()
-		repl.triggerDeferErrorCh <- err
+		select {
+		case repl.triggerDeferErrorCh <- err:
+		case <-stopCh:
+			doneCh <- nil
+			return
+		}
 		select {
 		case err := <-err.errCh:
 			if err != nil {

--- a/raft_test.go
+++ b/raft_test.go
@@ -2869,6 +2869,38 @@ func TestRaft_LeadershipTransferStopRightAway(t *testing.T) {
 	}
 }
 
+func TestRaft_LeadershipTransferStopsWhenReplicationIsUnavailable(t *testing.T) {
+	r := Raft{leaderState: leaderState{}, logger: hclog.New(nil)}
+	r.setupLeaderState()
+	r.setLastLog(1, 1)
+
+	repl := &followerReplication{
+		nextIndex:           1,
+		triggerDeferErrorCh: make(chan *deferError, 1),
+	}
+	// Simulate a replication worker that stopped with a pending request.
+	repl.triggerDeferErrorCh <- &deferError{}
+
+	stopCh := make(chan struct{})
+	doneCh := make(chan error, 1)
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		r.leadershipTransfer(ServerID("a"), ServerAddress(""), repl, stopCh, doneCh)
+	}()
+	<-started
+	// Give leadershipTransfer time to reach the full replication channel.
+	time.Sleep(10 * time.Millisecond)
+	close(stopCh)
+
+	select {
+	case err := <-doneCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("leadership transfer did not stop after replication became unavailable")
+	}
+}
+
 func TestRaft_GetConfigurationNoBootstrap(t *testing.T) {
 	c := MakeCluster(2, t, nil)
 	defer c.Close()


### PR DESCRIPTION
## Description

Stop a leadership-transfer goroutine when the leader loop exits while the follower replication worker cannot accept another trigger request.

The trigger send now also observes the existing `stopCh`. This lets the caller finish the transfer future and clear `leadershipTransferInProgress` instead of waiting forever on a full replication channel.

The regression test fills that channel, starts a transfer, closes `stopCh`, and verifies that the transfer exits.

## Related Issue

Fixes #696.

## How Has This Been Tested?

- `go test -timeout=180s -race .`
- `go test -timeout=180s -tags batchtest -race .`
- `go test -timeout=90s -race -count=30 -run 'TestRaft_LeadershipTransfer(StopsWhenReplicationIsUnavailable|StopsRightAway)$' .`
- `go vet ./...`
- `git diff --check origin/main...HEAD`
